### PR TITLE
release: Yuki 3.3.1 web provider router

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -264,6 +264,12 @@ WEB_MODE=native
 WEB_ENABLED=false
 # 仅 tavily / native_with_tavily_fallback 模式需要。
 TAVILY_API_KEY=replace-with-tavily-api-key
+# 混合模式下，明确 URL 命中这些域名时直接交给 Tavily；子域名也会匹配。
+WEB_TAVILY_DOMAINS=github.com,raw.githubusercontent.com
+# 允许用户在当前消息中明确要求使用 Tavily 或 DeepSeek 原生联网。
+WEB_ALLOW_PROVIDER_OVERRIDE=true
+WEB_FALLBACK_ON_ACCESS_DENIED=true
+WEB_FALLBACK_ON_TARGET_MISS=true
 WEB_SEARCH_DEPTH=advanced
 WEB_SEARCH_MAX_RESULTS=5
 WEB_EXTRACT_MAX_RESULTS=3

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@
 </p>
 
 <p>
-  <img src="https://img.shields.io/badge/Version-3.3.0-blue" alt="Version">
+  <img src="https://img.shields.io/badge/Version-3.3.1-blue" alt="Version">
   <img src="https://img.shields.io/badge/Python-3.12%2B-3776AB?logo=python&logoColor=white" alt="Python Version">
   <img src="https://img.shields.io/badge/NoneBot2-OneBot%20v11-green" alt="NoneBot2">
   <img src="https://img.shields.io/badge/Deploy-Docker%20Compose-2496ED?logo=docker&logoColor=white" alt="Docker Compose">
@@ -36,11 +36,11 @@
 
 Yuki 是一个纯用 Codex vibe coding 开发、面向个人部署的 QQ AI Agent。它通过 NapCatQQ 接入 QQ，使用 Planner、Agent、长期记忆、工具系统和插件系统完成聊天、检索、自动化与外部服务调用。
 
-> **当前版本：3.3.0**
+> **当前版本：3.3.1**
 >
-> 本版本新增 DeepSeek Responses API 与 Provider 原生联网搜索，Tavily 可继续独立使用或作为
-> 有界回退。Planner 选择的工具 scope 会保留，自动化提示只追加 `automation` 候选能力，
-> 由 Yuki 自行判断当前请求需要联网、立即执行还是创建持久化任务。
+> 本版本新增精简 Web Provider 路由器：混合模式可按用户显式选择和目标域名在 DeepSeek
+> 原生联网与 Tavily 之间选择；原生访问失败、未打开指定 URL 或缺少必需来源时只进行一次
+> 有界回退。Router 只选择联网后端，不会自行授予 web 权限或强迫 Yuki 联网。
 
 ## ✨ 主要功能
 

--- a/docs/help.md
+++ b/docs/help.md
@@ -1,5 +1,9 @@
 # Yuki-QQbot
 
+> **3.3.1 Web Provider 规则路由：**混合模式支持用户显式选择和域名直达 Tavily；
+> DeepSeek 原生访问失败、没有打开明确目标 URL 或无法提供所需来源时，只允许一次 Tavily
+> 回退。Router 不改变 Planner 的 web 授权，也不会强迫 Agent 调用联网工具。
+
 > **3.3.0 DeepSeek Responses API 与原生联网：**主聊天模型可使用 `/responses`、Function Tool
 > 续接和 Provider 原生 `web_search`。`WEB_MODE` 支持 native、tavily、原生优先有界回退和禁用；
 > 自动化识别只追加候选 scope，不再覆盖 Planner 已选择的 web、memory、MCP 等能力。
@@ -79,7 +83,7 @@ docker compose down
 
 ## 项目定位
 
-Yuki-QQbot 3.3.0 是基于 Python 3.12、NoneBot2、OneBot v11、NapCatQQ、SQLite 和 OpenAI-compatible Chat Completions / Responses API 的人物中心 QQ Agent。
+Yuki-QQbot 3.3.1 是基于 Python 3.12、NoneBot2、OneBot v11、NapCatQQ、SQLite 和 OpenAI-compatible Chat Completions / Responses API 的人物中心 QQ Agent。
 
 - QQ 号字符串是人物的全局唯一身份。
 - 当前消息发送者的 QQ 是否属于 `SUPERUSERS`，是唯一管理员凭证。
@@ -943,7 +947,7 @@ Worker 默认每 2 秒轮询，用租约防止多实例重复执行，并以 `(a
 
 ## 受控联网搜索
 
-3.3.0 推荐使用 DeepSeek Responses 原生联网，不需要 Tavily Key：
+可以只使用 DeepSeek Responses 原生联网，不需要 Tavily Key：
 
 ```dotenv
 WEB_MODE=native
@@ -968,6 +972,11 @@ chat_agent = "pro"
 # WEB_MODE=tavily
 WEB_MODE=native_with_tavily_fallback
 TAVILY_API_KEY=你的Tavily密钥
+# 明确 URL 命中以下域名时直接使用 Tavily；子域名也会匹配。
+WEB_TAVILY_DOMAINS=github.com,raw.githubusercontent.com
+WEB_ALLOW_PROVIDER_OVERRIDE=true
+WEB_FALLBACK_ON_ACCESS_DENIED=true
+WEB_FALLBACK_ON_TARGET_MISS=true
 WEB_SEARCH_DEPTH=advanced
 ```
 
@@ -983,6 +992,12 @@ docker compose up -d --build --no-deps bot
 - `WEB_MODE=native`：只使用 Responses 原生联网，不创建本地 Tavily 客户端。
 - `WEB_MODE=tavily`：只使用本地 Tavily Function Tool，必须配置 `TAVILY_API_KEY`。
 - `WEB_MODE=native_with_tavily_fallback`：原生优先并允许一次有界 Tavily 回退，也必须配置 Key。
+- 混合模式下，`WEB_TAVILY_DOMAINS` 使用逗号分隔域名。规则按主机名边界匹配，
+  `github.com` 会匹配 `api.github.com`，不会匹配 `evilgithub.com`。
+- `WEB_ALLOW_PROVIDER_OVERRIDE=true` 时，用户可在当前消息中明确要求使用 Tavily 或
+  DeepSeek 原生联网；网页正文和工具结果不能改变 Provider。
+- 原生 `open_page` 失败或没有真正打开用户明确给出的目标 URL 时，可进行一次
+  `native -> Tavily` 回退；不会在两个 Provider 之间循环。
 - 未设置 `WEB_MODE` 时兼容旧 `WEB_ENABLED`：`true` 映射为 `tavily`，`false` 映射为
   `disabled`。
 - 搜索词最多 400 字符，不会自动拼入完整聊天历史、人物记忆或系统提示词。

--- a/docs/plugin-development/index.md
+++ b/docs/plugin-development/index.md
@@ -47,7 +47,7 @@ Yuki 2.0.0 不改变 Plugin API `1.0` 的公共含义。插件 Prompt Fragment �
 
 | 标识 | 当前值 | 用途 |
 |---|---:|---|
-| Yuki | `3.3.0` | Host 产品版本 |
+| Yuki | `3.3.1` | Host 产品版本 |
 | Plugin API | `1.0` | SDK 主兼容边界 |
 | Event/Tool/Automation Schema | `1` | 单类载荷的结构版本 |
 | Feature | 如 `planner.signal.v1` | 运行时能力探测 |

--- a/docs/releases/v3.3.1.md
+++ b/docs/releases/v3.3.1.md
@@ -1,0 +1,60 @@
+# Yuki-QQbot 3.3.1 发布说明
+
+3.3.1 在 3.3.0 的 DeepSeek Responses 原生联网与 Tavily 有界回退基础上，加入精简的
+Web Provider 规则路由器。Router 只在 Planner 已授权联网后选择执行后端，不会扩大工具权限，
+也不会强迫 Yuki 使用联网工具。Plugin API 仍为 `1.0`，本版本不新增数据库迁移，Alembic
+head 保持 `0027`。
+
+## Provider 路由
+
+- `native_with_tavily_fallback` 模式默认从 DeepSeek 原生联网开始；纯 `native`、纯 `tavily`
+  和禁用模式保持原有行为。
+- 普通用户可以在当前消息中明确要求使用 Tavily 或 DeepSeek 原生联网。只读取当前用户消息，
+  网页正文、工具结果和长期记忆不能改变 Provider。
+- `WEB_TAVILY_DOMAINS` 可配置逗号分隔的域名规则。规则按主机名边界匹配：`github.com`
+  可以匹配 `api.github.com`，不会误匹配 `evilgithub.com`。
+- 本地默认测试配置将 `github.com` 和 `raw.githubusercontent.com` 交给 Tavily；`.env` 不会
+  提交到仓库，部署者可自行选择规则。
+
+## 有界回退
+
+- DeepSeek 原生事件明确失败时，可以切换到 Tavily。
+- 用户给出明确 URL，而原生事件和引用均未打开对应页面时，可以切换到 Tavily。
+- 用户要求附来源而原生结果无法恢复真实来源时，可以切换到 Tavily。
+- 每轮只允许一次 `native -> Tavily`，不会在两个 Provider 之间循环；用户明确要求只用原生
+  时不会回退。
+- URL 继续经过公开 HTTP(S) 校验，本地地址、私有 IP、凭据 URL 和内部 Docker 主机不会被
+  路由规则放行。
+
+## 配置
+
+```dotenv
+WEB_MODE=native_with_tavily_fallback
+TAVILY_API_KEY=你的Tavily密钥
+WEB_TAVILY_DOMAINS=github.com,raw.githubusercontent.com
+WEB_ALLOW_PROVIDER_OVERRIDE=true
+WEB_FALLBACK_ON_ACCESS_DENIED=true
+WEB_FALLBACK_ON_TARGET_MISS=true
+```
+
+## 可观测性
+
+- `web_route_selected` 记录 Provider、稳定原因、命中域名、尝试次数和是否允许回退；
+- 只有 Planner 实际授权 web scope 时才记录选择，普通闲聊不会产生无意义路由日志；
+- 日志不记录完整用户消息、搜索词、完整 URL 或 API Key。
+
+## 升级
+
+本版本没有数据库迁移。更新后只需重建 Bot，`--no-deps` 不会重建 NapCat：
+
+```bash
+docker compose up -d --build --no-deps bot
+```
+
+## 发布验证
+
+- `ruff format --check .`、`ruff check .` 通过；
+- 严格 `mypy src` 通过；
+- 全量测试 `890 passed, 1 skipped`；跳过项需要显式 Qwen Embedding 在线凭据；
+- Bot 3.3.1 镜像构建和健康检查通过，OneBot 反向 WebSocket 已恢复连接；
+- NapCat 容器 ID、创建时间与 QQ 登录状态在 Bot 重建期间保持不变。

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "qq-ai-bot"
-version = "3.3.0"
+version = "3.3.1"
 description = "基于 NoneBot2、OneBot v11 与 NapCatQQ 的个人 QQ AI 聊天机器人"
 readme = "README.md"
 requires-python = ">=3.12,<3.13"

--- a/src/qq_ai_bot/__init__.py
+++ b/src/qq_ai_bot/__init__.py
@@ -1,3 +1,3 @@
 """QQ AI Bot application package."""
 
-__version__ = "3.3.0"
+__version__ = "3.3.1"

--- a/src/qq_ai_bot/config.py
+++ b/src/qq_ai_bot/config.py
@@ -273,6 +273,10 @@ class Settings(BaseSettings):
     web_tool_result_max_characters: int = 16000
     web_source_retention_days: int = 7
     web_source_max_runs_per_conversation: int = 10
+    web_tavily_domains_csv: str = Field(default="", validation_alias="WEB_TAVILY_DOMAINS")
+    web_allow_provider_override: bool = True
+    web_fallback_on_access_denied: bool = True
+    web_fallback_on_target_miss: bool = True
 
     vision_enabled: bool = False
     vision_provider: str = "qwen"
@@ -627,6 +631,12 @@ class Settings(BaseSettings):
     @cached_property
     def ignored_bot_users(self) -> frozenset[str]:
         return _csv_set(self.ignored_bot_users_csv)
+
+    @property
+    def web_tavily_domains(self) -> frozenset[str]:
+        """Domains routed directly to Tavily in hybrid web mode."""
+
+        return _csv_set(self.web_tavily_domains_csv)
 
     @property
     def sqlite_path(self) -> Path | None:

--- a/src/qq_ai_bot/memory/quality/release_check.py
+++ b/src/qq_ai_bot/memory/quality/release_check.py
@@ -42,7 +42,7 @@ class MemoryReleaseCheck:
         items.append(
             self._item(
                 "version",
-                __version__ == "3.3.0",
+                __version__ == "3.3.1",
                 f"project version is {__version__}",
             )
         )

--- a/src/qq_ai_bot/services/agent_runner.py
+++ b/src/qq_ai_bot/services/agent_runner.py
@@ -35,7 +35,13 @@ from qq_ai_bot.model_runtime.models import ModelTask
 from qq_ai_bot.services.concurrency import ConcurrencyManager
 from qq_ai_bot.services.native_tool_binder import NativeToolBinder
 from qq_ai_bot.time.models import TimeContext
-from qq_ai_bot.web.models import WebMode
+from qq_ai_bot.web.models import (
+    WebMode,
+    WebProvider,
+    WebRouteDecision,
+    WebRouteReason,
+)
+from qq_ai_bot.web.router import WebProviderRouter
 
 logger = logging.getLogger(__name__)
 
@@ -56,6 +62,7 @@ class AgentRuntime:
     max_tool_calls: int
     max_model_requests: int
     force_tavily_fallback: bool = False
+    web_route: WebRouteDecision | None = None
 
 
 @dataclass(frozen=True, slots=True)
@@ -67,6 +74,7 @@ class AgentRunResult:
     native_tool_events: tuple[NativeToolEvent, ...] = ()
     citations: tuple[ResponseCitation, ...] = ()
     response_status: ModelResponseStatus = ModelResponseStatus.COMPLETED
+    web_route: WebRouteDecision | None = None
 
 
 class AgentToolBackend(Protocol):
@@ -92,6 +100,7 @@ class AgentRunner:
         concurrency: ConcurrencyManager,
         *,
         task: ModelTask = ModelTask.CHAT_AGENT,
+        web_router: WebProviderRouter | None = None,
     ) -> None:
         if callable(getattr(model_executor, "execute", None)):
             self._models = cast(ModelExecutor, model_executor)
@@ -104,6 +113,7 @@ class AgentRunner:
         self._task = task
         self._tool_coordinator = ToolInvocationCoordinator()
         self._native_tools = NativeToolBinder()
+        self._web_router = web_router or WebProviderRouter()
 
     async def run(
         self,
@@ -121,7 +131,11 @@ class AgentRunner:
         citations: list[ResponseCitation] = []
         response_status = ModelResponseStatus.COMPLETED
         incomplete_recovery_used = False
-        tavily_fallback = runtime.force_tavily_fallback
+        web_route = runtime.web_route
+        tavily_fallback = bool(
+            runtime.force_tavily_fallback
+            or (web_route is not None and web_route.provider is WebProvider.TAVILY)
+        )
         if tavily_fallback and tools is not None:
             enable_fallback = getattr(tools, "enable_native_web_fallback", None)
             if callable(enable_fallback):
@@ -180,9 +194,20 @@ class AgentRunner:
                     ),
                     fallback_used=tavily_fallback,
                     has_request_budget=request_index + 1 < runtime.max_model_requests,
-                    reason=type(exc).__name__,
+                    reason=(
+                        WebRouteReason.NATIVE_TIMEOUT
+                        if isinstance(exc, LLMTimeoutError)
+                        else WebRouteReason.NATIVE_UNAVAILABLE
+                    ),
+                    web_route=web_route,
                 ):
                     tavily_fallback = True
+                    web_route = self._fallback_route(
+                        web_route,
+                        WebRouteReason.NATIVE_TIMEOUT
+                        if isinstance(exc, LLMTimeoutError)
+                        else WebRouteReason.NATIVE_UNAVAILABLE,
+                    )
                     continue
                 raise
             except LLMEmptyResponseError:
@@ -192,9 +217,11 @@ class AgentRunner:
                     native_was_offered=bool(native_definitions),
                     fallback_used=tavily_fallback,
                     has_request_budget=request_index + 1 < runtime.max_model_requests,
-                    reason="empty_response",
+                    reason=WebRouteReason.NATIVE_EMPTY,
+                    web_route=web_route,
                 ):
                     tavily_fallback = True
+                    web_route = self._fallback_route(web_route, WebRouteReason.NATIVE_EMPTY)
                     continue
                 has_visible_effects = bool(
                     tools is not None
@@ -210,6 +237,7 @@ class AgentRunner:
                         native_tool_events=tuple(native_events),
                         citations=tuple(citations),
                         response_status=response_status,
+                        web_route=web_route,
                     )
                 if empty_retries >= 2 or request_index + 1 >= runtime.max_model_requests:
                     raise
@@ -261,6 +289,27 @@ class AgentRunner:
                     response.incomplete_reason or "unknown",
                 )
                 continue
+            terminal_web_failure = (
+                self._web_router.native_terminal_failure(
+                    web_route,
+                    events=tuple(native_events),
+                    citations=tuple(citations),
+                )
+                if not response.tool_calls
+                else None
+            )
+            if terminal_web_failure is not None and self._enable_tavily_fallback(
+                tools=tools,
+                web_mode=web_mode,
+                native_was_offered=True,
+                fallback_used=tavily_fallback,
+                has_request_budget=request_index + 1 < runtime.max_model_requests,
+                reason=terminal_web_failure,
+                web_route=web_route,
+            ):
+                tavily_fallback = True
+                web_route = self._fallback_route(web_route, terminal_web_failure)
+                continue
             if not response.tool_calls:
                 content = response.content
                 if tools is not None:
@@ -298,6 +347,7 @@ class AgentRunner:
                     native_tool_events=tuple(native_events),
                     citations=tuple(citations),
                     response_status=response_status,
+                    web_route=web_route,
                 )
             responses_path = response.continuation is not None
             if not responses_path:
@@ -358,6 +408,7 @@ class AgentRunner:
             native_tool_events=tuple(native_events),
             citations=tuple(citations),
             response_status=response_status,
+            web_route=web_route,
         )
 
     @staticmethod
@@ -368,7 +419,8 @@ class AgentRunner:
         native_was_offered: bool,
         fallback_used: bool,
         has_request_budget: bool,
-        reason: str,
+        reason: WebRouteReason,
+        web_route: WebRouteDecision | None,
     ) -> bool:
         if (
             tools is None
@@ -376,6 +428,7 @@ class AgentRunner:
             or not native_was_offered
             or fallback_used
             or not has_request_budget
+            or (web_route is not None and not WebProviderRouter.can_fallback(web_route))
         ):
             return False
         enable = getattr(tools, "enable_native_web_fallback", None)
@@ -385,6 +438,20 @@ class AgentRunner:
         logger.warning(
             "web_provider_fallback from_provider=deepseek_native to_provider=tavily "
             "reason_category=%s",
-            reason,
+            reason.value,
         )
         return True
+
+    @staticmethod
+    def _fallback_route(
+        web_route: WebRouteDecision | None,
+        reason: WebRouteReason,
+    ) -> WebRouteDecision:
+        if web_route is not None:
+            return WebProviderRouter.fallback(web_route, reason)
+        return WebRouteDecision(
+            provider=WebProvider.TAVILY,
+            reason=reason,
+            fallback_allowed=False,
+            attempt=2,
+        )

--- a/src/qq_ai_bot/services/agent_tools.py
+++ b/src/qq_ai_bot/services/agent_tools.py
@@ -54,6 +54,7 @@ from qq_ai_bot.speech.reply_effect import PendingVoiceReplyEffect
 from qq_ai_bot.web.base import WebSearchError, WebSearchProvider, normalize_public_url
 from qq_ai_bot.web.models import (
     WebMode,
+    WebRouteDecision,
     WebSearchRequest,
     WebSearchResponse,
     WebSearchTimeRange,
@@ -109,6 +110,7 @@ class ToolRuntime:
     scheduled_automation_intent: bool = False
     max_model_requests_override: int | None = None
     native_web_fallback: bool = False
+    web_route: WebRouteDecision | None = None
 
 
 @dataclass(frozen=True, slots=True)

--- a/src/qq_ai_bot/services/chat.py
+++ b/src/qq_ai_bot/services/chat.py
@@ -125,7 +125,9 @@ from qq_ai_bot.speech.reply_effect import (
 )
 from qq_ai_bot.time.service import TimeContextService
 from qq_ai_bot.vision.models import VisualObservation
+from qq_ai_bot.web.models import WebProvider
 from qq_ai_bot.web.native_sources import recover_native_web_response
+from qq_ai_bot.web.router import WebProviderRouter
 from yuki_plugin_sdk.events import EventName
 
 logger = logging.getLogger(__name__)
@@ -997,7 +999,13 @@ class ChatService:
         self._source_policy = source_policy or SourceDisplayPolicy()
         self._source_renderer = source_renderer or SourceRenderer()
         self._runtime_config = runtime_config
-        self._agent_runner = AgentRunner(models, concurrency)
+        self._web_router = WebProviderRouter(
+            tavily_domains=settings.web.tavily_domains,
+            allow_provider_override=settings.web.web_allow_provider_override,
+            fallback_on_access_denied=settings.web.web_fallback_on_access_denied,
+            fallback_on_target_miss=settings.web.web_fallback_on_target_miss,
+        )
+        self._agent_runner = AgentRunner(models, concurrency, web_router=self._web_router)
         self._tool_selector = ToolCandidateSelector()
         self._tool_reranker = FlashToolReranker(models)
         self._admin_tools: AdminToolService | None = None
@@ -1387,6 +1395,22 @@ class ChatService:
             tool_groups = planner_tool_groups
             if scheduled_automation_allowed and (planned_turn is None or planner_scopes_explicit):
                 tool_groups = frozenset((*tool_groups, ToolGroup.AUTOMATION.value))
+            web_route = self._web_router.select(content, runtime_config.web.mode)
+            web_scope_authorized = not planner_scopes_explicit or any(
+                scope == ToolGroup.WEB.value or scope.startswith(f"{ToolGroup.WEB.value}.")
+                for scope in tool_groups
+            )
+            if web_route is not None and web_scope_authorized:
+                logger.info(
+                    "web_route_selected conversation_hash=%s provider=%s reason=%s "
+                    "matched_domain=%s attempt=%d fallback_allowed=%s",
+                    identifier_hash(identity.key) or "missing",
+                    web_route.provider.value,
+                    web_route.reason.value,
+                    web_route.matched_domain or "none",
+                    web_route.attempt,
+                    web_route.fallback_allowed,
+                )
             runtime = ToolRuntime(
                 inbound=inbound,
                 gateway=gateway,
@@ -1436,6 +1460,10 @@ class ChatService:
                 planner_intent=(planned_turn.plan.intent if planned_turn is not None else ""),
                 scheduled_automation_intent=scheduled_automation_allowed,
                 max_model_requests_override=(1 if fallback_plan else None),
+                native_web_fallback=bool(
+                    web_route is not None and web_route.provider is WebProvider.TAVILY
+                ),
+                web_route=web_route,
             )
             if planner_emoji_only:
                 response_text = ""
@@ -1465,14 +1493,17 @@ class ChatService:
                             identifier_hash(identity.key) or "missing",
                             len(agent_result.native_tool_events),
                         )
-                        if (
-                            source_display_requested
-                            and runtime_config.web.mode == "native_with_tavily_fallback"
-                            and not runtime.native_web_fallback
-                        ):
+                        completed_route = agent_result.web_route
+                        source_failure = self._web_router.missing_source_failure(
+                            completed_route,
+                            source_display_requested=source_display_requested,
+                            source_count=len(native_response.sources),
+                        )
+                        if source_failure is not None and completed_route is not None:
                             logger.warning(
                                 "web_provider_fallback from_provider=deepseek_native "
-                                "to_provider=tavily reason_category=source_parse_failed"
+                                "to_provider=tavily reason_category=%s",
+                                source_failure.value,
                             )
                             fallback_limit = min(
                                 2,
@@ -1482,6 +1513,10 @@ class ChatService:
                             fallback_runtime = replace(
                                 runtime,
                                 native_web_fallback=True,
+                                web_route=self._web_router.fallback(
+                                    completed_route,
+                                    source_failure,
+                                ),
                                 max_model_requests_override=fallback_limit,
                             )
                             agent_result = await self._run_agent(
@@ -1908,6 +1943,7 @@ class ChatService:
                     else config.agent.max_model_requests
                 ),
                 force_tavily_fallback=runtime.native_web_fallback,
+                web_route=runtime.web_route,
             ),
             _ChatAgentBackend(self, runtime),
         )

--- a/src/qq_ai_bot/settings_domains.py
+++ b/src/qq_ai_bot/settings_domains.py
@@ -281,6 +281,10 @@ class WebSettings(DomainSettings):
     web_tool_result_max_characters: int = Field(gt=0)
     web_source_retention_days: int = Field(gt=0)
     web_source_max_runs_per_conversation: int = Field(gt=0)
+    web_tavily_domains_csv: str = ""
+    web_allow_provider_override: bool = True
+    web_fallback_on_access_denied: bool = True
+    web_fallback_on_target_miss: bool = True
 
     @model_validator(mode="after")
     def _credentials(self) -> WebSettings:
@@ -297,6 +301,12 @@ class WebSettings(DomainSettings):
         if self.web_mode is not None:
             return self.web_mode
         return WebMode.TAVILY if self.web_enabled else WebMode.DISABLED
+
+    @property
+    def tavily_domains(self) -> frozenset[str]:
+        return frozenset(
+            item.strip() for item in self.web_tavily_domains_csv.split(",") if item.strip()
+        )
 
 
 class VisionSettings(DomainSettings):

--- a/src/qq_ai_bot/web/models.py
+++ b/src/qq_ai_bot/web/models.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 from datetime import date, datetime
 from enum import StrEnum
 from typing import Literal
@@ -18,6 +18,40 @@ class WebMode(StrEnum):
     NATIVE = "native"
     TAVILY = "tavily"
     NATIVE_WITH_TAVILY_FALLBACK = "native_with_tavily_fallback"
+
+
+class WebProvider(StrEnum):
+    """Concrete provider selected for one web-capable Agent run."""
+
+    NATIVE = "native"
+    TAVILY = "tavily"
+
+
+class WebRouteReason(StrEnum):
+    """Stable, non-sensitive explanation for a provider routing decision."""
+
+    MODE = "mode"
+    USER_OVERRIDE = "user_override"
+    DOMAIN_RULE = "domain_rule"
+    DEFAULT_NATIVE = "default_native"
+    NATIVE_TIMEOUT = "native_timeout"
+    NATIVE_UNAVAILABLE = "native_unavailable"
+    NATIVE_EMPTY = "native_empty"
+    NATIVE_ACCESS_DENIED = "native_access_denied"
+    TARGET_NOT_OPENED = "target_not_opened"
+    SOURCE_NOT_RECOVERED = "source_not_recovered"
+
+
+@dataclass(frozen=True, slots=True)
+class WebRouteDecision:
+    """One bounded and auditable provider selection for the current turn."""
+
+    provider: WebProvider
+    reason: WebRouteReason
+    fallback_allowed: bool
+    attempt: int = 1
+    matched_domain: str | None = None
+    target_urls: tuple[str, ...] = field(default=(), repr=False)
 
 
 @dataclass(frozen=True, slots=True)

--- a/src/qq_ai_bot/web/router.py
+++ b/src/qq_ai_bot/web/router.py
@@ -1,0 +1,247 @@
+"""Deterministic provider routing for backend-authorized web access."""
+
+from __future__ import annotations
+
+import re
+from dataclasses import replace
+from urllib.parse import urlsplit
+
+from qq_ai_bot.domain.messages import NativeToolEvent, NativeToolStatus, ResponseCitation
+from qq_ai_bot.web.base import WebSearchError, normalize_public_url
+from qq_ai_bot.web.models import (
+    WebMode,
+    WebProvider,
+    WebRouteDecision,
+    WebRouteReason,
+)
+
+_URL = re.compile(r"https?://[^\s<>'\"]+", re.IGNORECASE)
+_TRAILING_PUNCTUATION = ".,;:!?)]}，。；：！？）】》"
+_TAVILY_OVERRIDE = re.compile(
+    r"(?:请|这次|直接|只)?\s*(?:用|使用|通过|走|改用|换(?:成|用)?)"
+    r"\s*(?:tavil(?:y|ity)|塔维利)",
+    re.IGNORECASE,
+)
+_NATIVE_OVERRIDE = re.compile(
+    r"(?:请|这次|直接|只)?\s*(?:用|使用|通过|走|改用|换(?:成|用)?)"
+    r"\s*(?:deepseek\s*)?(?:原生|native)(?:联网|搜索|访问)?",
+    re.IGNORECASE,
+)
+_CONDITIONAL_TAVILY = re.compile(
+    r"(?:打不开|访问不了|失败|不行).{0,16}(?:就|再|则).{0,12}"
+    r"(?:tavil(?:y|ity)|塔维利)",
+    re.IGNORECASE,
+)
+
+
+class WebProviderRouter:
+    """Select native or Tavily without granting the web capability itself."""
+
+    def __init__(
+        self,
+        *,
+        tavily_domains: frozenset[str] = frozenset(),
+        allow_provider_override: bool = True,
+        fallback_on_access_denied: bool = True,
+        fallback_on_target_miss: bool = True,
+    ) -> None:
+        self._tavily_domains = frozenset(
+            normalized
+            for item in tavily_domains
+            if (normalized := self._normalize_domain_rule(item))
+        )
+        self._allow_provider_override = allow_provider_override
+        self._fallback_on_access_denied = fallback_on_access_denied
+        self._fallback_on_target_miss = fallback_on_target_miss
+
+    def select(self, message: str, mode: WebMode | str) -> WebRouteDecision | None:
+        """Choose the initial provider from deployment mode and current user input."""
+
+        try:
+            resolved_mode = WebMode(mode)
+        except ValueError:
+            return None
+        target_urls = self.extract_public_urls(message)
+        if resolved_mode is WebMode.DISABLED:
+            return None
+        if resolved_mode is WebMode.TAVILY:
+            return WebRouteDecision(
+                provider=WebProvider.TAVILY,
+                reason=WebRouteReason.MODE,
+                fallback_allowed=False,
+                target_urls=target_urls,
+            )
+        if resolved_mode is WebMode.NATIVE:
+            return WebRouteDecision(
+                provider=WebProvider.NATIVE,
+                reason=WebRouteReason.MODE,
+                fallback_allowed=False,
+                target_urls=target_urls,
+            )
+
+        override = self._provider_override(message)
+        if override is WebProvider.TAVILY:
+            return WebRouteDecision(
+                provider=override,
+                reason=WebRouteReason.USER_OVERRIDE,
+                fallback_allowed=False,
+                target_urls=target_urls,
+            )
+        if override is WebProvider.NATIVE:
+            return WebRouteDecision(
+                provider=override,
+                reason=WebRouteReason.USER_OVERRIDE,
+                fallback_allowed=False,
+                target_urls=target_urls,
+            )
+        for url in target_urls:
+            host = self._host(url)
+            matched = self._matching_domain(host)
+            if matched is not None:
+                return WebRouteDecision(
+                    provider=WebProvider.TAVILY,
+                    reason=WebRouteReason.DOMAIN_RULE,
+                    fallback_allowed=False,
+                    matched_domain=matched,
+                    target_urls=target_urls,
+                )
+        return WebRouteDecision(
+            provider=WebProvider.NATIVE,
+            reason=WebRouteReason.DEFAULT_NATIVE,
+            fallback_allowed=True,
+            target_urls=target_urls,
+        )
+
+    def native_terminal_failure(
+        self,
+        decision: WebRouteDecision | None,
+        *,
+        events: tuple[NativeToolEvent, ...],
+        citations: tuple[ResponseCitation, ...],
+    ) -> WebRouteReason | None:
+        """Return a structured fallback reason for a completed native response."""
+
+        if not self.can_fallback(decision) or not events:
+            return None
+        opened = {
+            self._comparable_url(event.url)
+            for event in events
+            if event.status is NativeToolStatus.COMPLETED and event.url
+        }
+        opened.update(self._comparable_url(citation.url) for citation in citations)
+        targets = (
+            {self._comparable_url(url) for url in decision.target_urls}
+            if decision is not None
+            else set()
+        )
+        if targets.intersection(opened):
+            return None
+        if (
+            self._fallback_on_access_denied
+            and not opened
+            and any(event.status is NativeToolStatus.FAILED for event in events)
+        ):
+            return WebRouteReason.NATIVE_ACCESS_DENIED
+        if not self._fallback_on_target_miss or not targets:
+            return None
+        if targets and not targets.intersection(opened):
+            return WebRouteReason.TARGET_NOT_OPENED
+        return None
+
+    @staticmethod
+    def missing_source_failure(
+        decision: WebRouteDecision | None,
+        *,
+        source_display_requested: bool,
+        source_count: int,
+    ) -> WebRouteReason | None:
+        """Route an otherwise successful native answer when provenance is required."""
+
+        if (
+            source_display_requested
+            and source_count == 0
+            and WebProviderRouter.can_fallback(decision)
+        ):
+            return WebRouteReason.SOURCE_NOT_RECOVERED
+        return None
+
+    @staticmethod
+    def can_fallback(decision: WebRouteDecision | None) -> bool:
+        return bool(
+            decision is not None
+            and decision.provider is WebProvider.NATIVE
+            and decision.fallback_allowed
+            and decision.attempt == 1
+        )
+
+    @staticmethod
+    def fallback(
+        decision: WebRouteDecision,
+        reason: WebRouteReason,
+    ) -> WebRouteDecision:
+        """Create the only permitted native-to-Tavily transition."""
+
+        return replace(
+            decision,
+            provider=WebProvider.TAVILY,
+            reason=reason,
+            fallback_allowed=False,
+            attempt=2,
+        )
+
+    @staticmethod
+    def extract_public_urls(message: str) -> tuple[str, ...]:
+        urls: list[str] = []
+        for match in _URL.finditer(message):
+            candidate = match.group(0).rstrip(_TRAILING_PUNCTUATION)
+            try:
+                normalized = normalize_public_url(candidate)
+            except WebSearchError:
+                continue
+            if normalized not in urls:
+                urls.append(normalized)
+        return tuple(urls)
+
+    def _provider_override(self, message: str) -> WebProvider | None:
+        if not self._allow_provider_override:
+            return None
+        if _CONDITIONAL_TAVILY.search(message):
+            return None
+        tavily = _TAVILY_OVERRIDE.search(message)
+        native = _NATIVE_OVERRIDE.search(message)
+        if bool(tavily) == bool(native):
+            return None
+        return WebProvider.TAVILY if tavily else WebProvider.NATIVE
+
+    def _matching_domain(self, host: str) -> str | None:
+        return next(
+            (
+                rule
+                for rule in sorted(self._tavily_domains, key=len, reverse=True)
+                if host == rule or host.endswith(f".{rule}")
+            ),
+            None,
+        )
+
+    @staticmethod
+    def _normalize_domain_rule(rule: str) -> str:
+        candidate = rule.strip().casefold().lstrip("*.").rstrip(".")
+        if not candidate or "/" in candidate or ":" in candidate:
+            return ""
+        try:
+            return candidate.encode("idna").decode("ascii")
+        except UnicodeError:
+            return ""
+
+    @staticmethod
+    def _host(url: str) -> str:
+        return (urlsplit(url).hostname or "").casefold().rstrip(".")
+
+    @classmethod
+    def _comparable_url(cls, url: str) -> tuple[str, str]:
+        try:
+            parsed = urlsplit(normalize_public_url(url))
+        except WebSearchError:
+            return "", ""
+        path = parsed.path.rstrip("/") or "/"
+        return (parsed.hostname or "").casefold(), path

--- a/tests/integration/test_web_search_chat.py
+++ b/tests/integration/test_web_search_chat.py
@@ -272,6 +272,88 @@ class NativeSourceFailureThenTavilyLLM(LLMProvider):
         return ChatResponse(content="已通过备用搜索核验。", latency_seconds=0)
 
 
+class DomainRoutedTavilyLLM(LLMProvider):
+    """Use Tavily immediately when an explicit URL matches a routing rule."""
+
+    def __init__(self, url: str) -> None:
+        self.url = url
+        self.requests: list[ChatRequest] = []
+
+    async def complete(self, request: ChatRequest) -> ChatResponse:
+        self.requests.append(request)
+        if len(self.requests) == 1:
+            assert not request.native_tools
+            assert "read_webpage" in {tool.name for tool in request.tools}
+            return ChatResponse(
+                content="",
+                latency_seconds=0,
+                tool_calls=(
+                    ToolCall(
+                        id="domain-routed-read",
+                        function=ToolFunction(
+                            name="read_webpage",
+                            arguments=json.dumps(
+                                {"url": self.url, "question": "这个项目是什么"},
+                                ensure_ascii=False,
+                            ),
+                        ),
+                    ),
+                ),
+            )
+        payload = json.loads(request.messages[-1].content or "{}")
+        assert payload["ok"] is True
+        return ChatResponse(content="这个仓库是 Yuki QQ 机器人项目。", latency_seconds=0)
+
+
+class TargetMissThenTavilyLLM(LLMProvider):
+    """Fall back when native web completes without opening the requested URL."""
+
+    def __init__(self, url: str) -> None:
+        self.url = url
+        self.requests: list[ChatRequest] = []
+
+    async def complete(self, request: ChatRequest) -> ChatResponse:
+        self.requests.append(request)
+        if len(self.requests) == 1:
+            assert "read_webpage" not in {tool.name for tool in request.tools}
+            return ChatResponse(
+                content="原生搜索只找到了一篇无关页面。",
+                latency_seconds=0,
+                native_tool_events=(
+                    NativeToolEvent(
+                        tool_type=NativeToolType.WEB_SEARCH,
+                        call_id="native-other",
+                        status=NativeToolStatus.COMPLETED,
+                        action_type="open_page",
+                        url="https://example.com/other",
+                    ),
+                ),
+                citations=(
+                    ResponseCitation(
+                        url="https://example.com/other",
+                        origin=CitationOrigin.ANNOTATION,
+                    ),
+                ),
+            )
+        if len(self.requests) == 2:
+            assert not request.native_tools
+            assert "read_webpage" in {tool.name for tool in request.tools}
+            return ChatResponse(
+                content="",
+                latency_seconds=0,
+                tool_calls=(
+                    ToolCall(
+                        id="target-miss-read",
+                        function=ToolFunction(
+                            name="read_webpage",
+                            arguments=json.dumps({"url": self.url}, ensure_ascii=False),
+                        ),
+                    ),
+                ),
+            )
+        return ChatResponse(content="Tavily 已经读取到指定页面。", latency_seconds=0)
+
+
 def web_settings(database: Database):
     return make_settings(
         database.url,
@@ -339,6 +421,85 @@ async def test_explicit_source_request_uses_bounded_tavily_fallback(
     assert sender.messages[0].text == "已通过备用搜索核验。"
     assert "https://example.com/deepseek-update" in sender.messages[1].text
     assert len(llm.requests) == 3
+
+
+@pytest.mark.asyncio
+async def test_explicit_domain_rule_routes_directly_to_tavily(
+    database: Database,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    caplog.set_level("INFO")
+    target_url = "https://github.com/YuanYeYouTao/Yuki-QQbot"
+    source = WebSearchSource(
+        source_id="github-yuki",
+        title="Yuki-QQbot",
+        url=target_url,
+        domain="github.com",
+        snippet="Yuki QQ bot repository",
+        relevant_content="Yuki-QQbot is a QQ AI Agent project.",
+    )
+    settings = make_settings(
+        database.url,
+        web_enabled=False,
+        web_mode=WebMode.NATIVE_WITH_TAVILY_FALLBACK,
+        tavily_api_key="test-placeholder",
+        web_tavily_domains_csv="github.com",
+        split_daily_chat_sentences=False,
+    )
+    llm = DomainRoutedTavilyLLM(target_url)
+    web = FakeWebSearchProvider(extracted={target_url: source})
+    harness = build_harness(database, settings, llm, web_provider=web)
+    sender = MemorySender()
+
+    result = await harness.processor.handle(
+        event(f"请读取 {target_url} 并告诉我这个项目是什么。", message_id="domain-route"),
+        sender,
+    )
+
+    assert result.reason == "chat"
+    assert [message.text for message in sender.messages] == ["这个仓库是 Yuki QQ 机器人项目。"]
+    assert web.extract_requests == [(target_url, "这个项目是什么")]
+    assert len(llm.requests) == 2
+    assert "provider=tavily reason=domain_rule matched_domain=github.com" in caplog.text
+
+
+@pytest.mark.asyncio
+async def test_native_target_miss_falls_back_to_tavily_once(
+    database: Database,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    caplog.set_level("INFO")
+    target_url = "https://docs.example.org/required-page"
+    source = WebSearchSource(
+        source_id="required-page",
+        title="Required page",
+        url=target_url,
+        domain="docs.example.org",
+        snippet="Requested content",
+        relevant_content="The requested page content.",
+    )
+    settings = make_settings(
+        database.url,
+        web_enabled=False,
+        web_mode=WebMode.NATIVE_WITH_TAVILY_FALLBACK,
+        tavily_api_key="test-placeholder",
+        split_daily_chat_sentences=False,
+    )
+    llm = TargetMissThenTavilyLLM(target_url)
+    web = FakeWebSearchProvider(extracted={target_url: source})
+    harness = build_harness(database, settings, llm, web_provider=web)
+    sender = MemorySender()
+
+    result = await harness.processor.handle(
+        event(f"读取 {target_url} 并总结。", message_id="target-miss-route"),
+        sender,
+    )
+
+    assert result.reason == "chat"
+    assert [message.text for message in sender.messages] == ["Tavily 已经读取到指定页面。"]
+    assert web.extract_requests == [(target_url, "读取用户指定的网页")]
+    assert len(llm.requests) == 3
+    assert "reason_category=target_not_opened" in caplog.text
 
 
 @pytest.mark.asyncio

--- a/tests/unit/test_web_router.py
+++ b/tests/unit/test_web_router.py
@@ -1,0 +1,174 @@
+"""Deterministic web provider routing tests."""
+
+from __future__ import annotations
+
+from qq_ai_bot.config import Settings
+from qq_ai_bot.domain.messages import (
+    CitationOrigin,
+    NativeToolEvent,
+    NativeToolStatus,
+    NativeToolType,
+    ResponseCitation,
+)
+from qq_ai_bot.web.models import WebMode, WebProvider, WebRouteReason
+from qq_ai_bot.web.router import WebProviderRouter
+
+
+def test_hybrid_router_uses_domain_rules_with_host_boundaries() -> None:
+    router = WebProviderRouter(tavily_domains=frozenset({"github.com"}))
+
+    direct = router.select(
+        "读取 https://api.github.com/repos/example/project。",
+        WebMode.NATIVE_WITH_TAVILY_FALLBACK,
+    )
+    unrelated = router.select(
+        "读取 https://evilgithub.com/project。",
+        WebMode.NATIVE_WITH_TAVILY_FALLBACK,
+    )
+
+    assert direct is not None
+    assert direct.provider is WebProvider.TAVILY
+    assert direct.reason is WebRouteReason.DOMAIN_RULE
+    assert direct.matched_domain == "github.com"
+    assert direct.target_urls == ("https://api.github.com/repos/example/project",)
+    assert unrelated is not None
+    assert unrelated.provider is WebProvider.NATIVE
+    assert unrelated.reason is WebRouteReason.DEFAULT_NATIVE
+
+
+def test_router_settings_accept_public_environment_name() -> None:
+    settings = Settings(
+        _env_file=None,
+        WEB_TAVILY_DOMAINS="github.com, raw.githubusercontent.com",
+    )
+
+    assert settings.web.tavily_domains == frozenset({"github.com", "raw.githubusercontent.com"})
+
+
+def test_hybrid_router_honors_explicit_provider_without_misreading_conditional_fallback() -> None:
+    router = WebProviderRouter()
+
+    tavily = router.select(
+        "这次请用 Tavily 搜索官方文档",
+        WebMode.NATIVE_WITH_TAVILY_FALLBACK,
+    )
+    native = router.select(
+        "这次只用 DeepSeek 原生搜索",
+        WebMode.NATIVE_WITH_TAVILY_FALLBACK,
+    )
+    conditional = router.select(
+        "DeepSeek 打不开就再用 Tavility",
+        WebMode.NATIVE_WITH_TAVILY_FALLBACK,
+    )
+
+    assert tavily is not None and tavily.provider is WebProvider.TAVILY
+    assert tavily.reason is WebRouteReason.USER_OVERRIDE
+    assert native is not None and native.provider is WebProvider.NATIVE
+    assert native.reason is WebRouteReason.USER_OVERRIDE
+    assert not native.fallback_allowed
+    assert conditional is not None and conditional.provider is WebProvider.NATIVE
+    assert conditional.reason is WebRouteReason.DEFAULT_NATIVE
+    assert conditional.fallback_allowed
+
+
+def test_fixed_modes_ignore_hybrid_rules() -> None:
+    router = WebProviderRouter(tavily_domains=frozenset({"github.com"}))
+    url = "请用 Tavily 读取 https://github.com/example/project"
+
+    native = router.select(url, WebMode.NATIVE)
+    tavily = router.select(url, WebMode.TAVILY)
+
+    assert native is not None and native.provider is WebProvider.NATIVE
+    assert native.reason is WebRouteReason.MODE
+    assert tavily is not None and tavily.provider is WebProvider.TAVILY
+    assert tavily.reason is WebRouteReason.MODE
+    assert router.select(url, WebMode.DISABLED) is None
+
+
+def test_native_failure_and_target_miss_allow_only_one_fallback() -> None:
+    router = WebProviderRouter()
+    decision = router.select(
+        "读取 https://github.com/example/project",
+        WebMode.NATIVE_WITH_TAVILY_FALLBACK,
+    )
+    assert decision is not None
+
+    failed = (
+        NativeToolEvent(
+            tool_type=NativeToolType.WEB_SEARCH,
+            call_id="open-failed",
+            status=NativeToolStatus.FAILED,
+            action_type="open_page",
+            url="https://github.com/example/project",
+            error_category="access_denied",
+        ),
+    )
+    assert (
+        router.native_terminal_failure(decision, events=failed, citations=())
+        is WebRouteReason.NATIVE_ACCESS_DENIED
+    )
+
+    opened_other_page = (
+        NativeToolEvent(
+            tool_type=NativeToolType.WEB_SEARCH,
+            call_id="open-other",
+            status=NativeToolStatus.COMPLETED,
+            action_type="open_page",
+            url="https://example.com/other",
+        ),
+    )
+    assert (
+        router.native_terminal_failure(decision, events=opened_other_page, citations=())
+        is WebRouteReason.TARGET_NOT_OPENED
+    )
+    matching_citation = (
+        ResponseCitation(
+            url="https://github.com/example/project#readme",
+            origin=CitationOrigin.ANNOTATION,
+        ),
+    )
+    assert (
+        router.native_terminal_failure(
+            decision,
+            events=opened_other_page,
+            citations=matching_citation,
+        )
+        is None
+    )
+
+    fallback = router.fallback(decision, WebRouteReason.TARGET_NOT_OPENED)
+    assert fallback.provider is WebProvider.TAVILY
+    assert fallback.attempt == 2
+    assert not fallback.fallback_allowed
+    assert not router.can_fallback(fallback)
+    assert (
+        router.missing_source_failure(
+            decision,
+            source_display_requested=True,
+            source_count=0,
+        )
+        is WebRouteReason.SOURCE_NOT_RECOVERED
+    )
+
+
+def test_router_ignores_private_urls_and_can_disable_outcome_fallbacks() -> None:
+    router = WebProviderRouter(
+        tavily_domains=frozenset({"localhost"}),
+        fallback_on_access_denied=False,
+        fallback_on_target_miss=False,
+    )
+    decision = router.select(
+        "读取 http://localhost:8080/private",
+        WebMode.NATIVE_WITH_TAVILY_FALLBACK,
+    )
+    assert decision is not None
+    assert decision.target_urls == ()
+    failed = (
+        NativeToolEvent(
+            tool_type=NativeToolType.WEB_SEARCH,
+            call_id="failed",
+            status=NativeToolStatus.FAILED,
+            action_type="open_page",
+        ),
+    )
+    assert router.native_terminal_failure(decision, events=failed, citations=()) is None

--- a/uv.lock
+++ b/uv.lock
@@ -758,7 +758,7 @@ wheels = [
 
 [[package]]
 name = "qq-ai-bot"
-version = "3.3.0"
+version = "3.3.1"
 source = { editable = "." }
 dependencies = [
     { name = "aiosqlite" },


### PR DESCRIPTION
## 变更内容

- 新增精简 `WebProviderRouter`，在混合模式下按用户显式选择和目标域名选择 DeepSeek 原生联网或 Tavily
- 增加 `WEB_TAVILY_DOMAINS`、Provider 显式选择以及原生访问失败/目标 URL 未打开的单次回退
- 保留 Planner web scope 权限边界，Router 不授予能力，也不强迫 Agent 联网
- 增加结构化路由日志、URL 安全校验、域名边界匹配和防循环机制
- 更新版本为 3.3.1，并补齐帮助、示例配置和发布说明

## 原因与影响

DeepSeek 原生联网发生在 Provider 服务器端，本机代理无法改善它对部分站点的访问能力。3.3.0 的回退只能处理超时、空响应和缺少来源，无法在用户指定的页面未真正打开时稳定切换。

本 PR 将 Provider 选择收敛为后端可审计规则：普通请求默认原生联网，命中配置域名或用户明确要求时直接使用 Tavily；原生失败、目标页面缺失或必需来源无法恢复时最多回退一次。纯 native、纯 Tavily 和 disabled 模式不变。

## 验证

- `uv run ruff format --check .`
- `uv run ruff check .`
- `uv run mypy src`
- `uv run pytest -q`：890 passed, 1 skipped
- `uv run qq-ai-bot-cli memory release-check`：version 3.3.1、Alembic 0027、38/38 gates
- `docker compose up -d --build --no-deps bot`
- Bot `/healthz` 返回 3.3.1，OneBot V11 已重新连接
- NapCat 容器 ID 和创建时间在重建前后保持不变