### PR TITLE
release: Yuki 3.5.2 versioned Docker delivery

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,6 +1,10 @@
 # 将本文件复制为 .env，并把所有 replace-with-* 占位符替换为真实值。
 # 每个区块按功能组织；本地 .env 可使用同样的顺序和注释，切勿提交真实密钥。
 
+# === Yuki 与容器版本 ===
+# 正式部署固定具体版本；升级时先修改这里，再执行 docker compose pull/up。
+YUKI_VERSION=3.5.2
+
 # === NapCat / OneBot 连接与容器运行 ===
 ONEBOT_ACCESS_TOKEN=replace-with-a-long-random-token
 NAPCAT_WEBUI_TOKEN=replace-with-a-long-random-webui-token

--- a/.github/workflows/quality.yml
+++ b/.github/workflows/quality.yml
@@ -1,6 +1,13 @@
 name: Quality
 
 on:
+  workflow_call:
+    inputs:
+      force_docker:
+        description: Run Docker checks even when the change is documentation-only
+        required: false
+        default: false
+        type: boolean
   push:
     branches: [main]
   pull_request:
@@ -9,6 +16,47 @@ permissions:
   contents: read
 
 jobs:
+  changes:
+    runs-on: ubuntu-latest
+    outputs:
+      docker: ${{ steps.filter.outputs.docker }}
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+      - name: Detect runtime changes
+        id: filter
+        shell: bash
+        env:
+          FORCE_DOCKER: ${{ inputs.force_docker || false }}
+          EVENT_NAME: ${{ github.event_name }}
+          BEFORE_SHA: ${{ github.event.before }}
+          BASE_SHA: ${{ github.event.pull_request.base.sha }}
+          HEAD_SHA: ${{ github.sha }}
+        run: |
+          set -euo pipefail
+          if [[ "$FORCE_DOCKER" == "true" ]]; then
+            echo "docker=true" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+          if [[ "$EVENT_NAME" == "pull_request" ]]; then
+            base="$BASE_SHA"
+          else
+            base="$BEFORE_SHA"
+          fi
+          if [[ -z "$base" || "$base" =~ ^0+$ ]]; then
+            echo "docker=true" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+          docker=false
+          while IFS= read -r path; do
+            case "$path" in
+              README.md|CHANGELOG.md|docs/*|img/*|*.md) ;;
+              *) docker=true; break ;;
+            esac
+          done < <(git diff --name-only "$base" "$HEAD_SHA")
+          echo "docker=$docker" >> "$GITHUB_OUTPUT"
+
   memory-quality:
     runs-on: ubuntu-latest
     steps:
@@ -70,15 +118,25 @@ jobs:
         run: uv run pytest -q tests/unit/test_memory_migration_matrix.py
 
   docker:
+    needs: changes
+    if: needs.changes.outputs.docker == 'true'
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
+      - name: Resolve project version
+        shell: bash
+        run: |
+          version="$(sed -n 's/^version = "\([^"]*\)"/\1/p' pyproject.toml | head -n 1)"
+          test -n "$version"
+          echo "YUKI_VERSION=$version" >> "$GITHUB_ENV"
       - name: Validate Compose
-        run: docker compose config --quiet
+        run: |
+          docker compose config --quiet
+          docker compose -f docker-compose.yml -f docker-compose.dev.yml config --quiet
       - name: Build runtime image
-        run: docker compose build bot
+        run: docker compose -f docker-compose.yml -f docker-compose.dev.yml build bot
       - name: Build network-isolated speech worker image
-        run: docker compose --profile speech build genie-tts-worker
+        run: docker compose -f docker-compose.yml -f docker-compose.dev.yml --profile speech build genie-tts-worker
 
   speech-worker:
     runs-on: ubuntu-latest

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,274 @@
+name: Release
+
+on:
+  push:
+    tags:
+      - "v*.*.*"
+  workflow_dispatch:
+    inputs:
+      bootstrap:
+        description: Publish one-time bootstrap-amd64 tags so GHCR packages can be made public
+        required: true
+        default: true
+        type: boolean
+
+permissions:
+  contents: write
+  packages: write
+
+concurrency:
+  group: release-${{ github.ref }}
+  cancel-in-progress: false
+
+env:
+  BOT_IMAGE: ghcr.io/yuanyeyoutao/yuki-qqbot
+  WORKER_IMAGE: ghcr.io/yuanyeyoutao/yuki-genie-tts-worker
+
+jobs:
+  validate:
+    runs-on: ubuntu-latest
+    outputs:
+      mode: ${{ steps.release.outputs.mode }}
+      version: ${{ steps.release.outputs.version }}
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+      - name: Validate tag, version, and main ancestry
+        id: release
+        shell: bash
+        env:
+          EVENT_NAME: ${{ github.event_name }}
+          REF_NAME: ${{ github.ref_name }}
+          BOOTSTRAP: ${{ inputs.bootstrap || false }}
+        run: |
+          set -euo pipefail
+          git fetch --no-tags origin main:refs/remotes/origin/main
+          if [[ "$EVENT_NAME" == "workflow_dispatch" ]]; then
+            if [[ "$BOOTSTRAP" != "true" ]]; then
+              echo "workflow_dispatch is reserved for the one-time GHCR bootstrap" >&2
+              exit 1
+            fi
+            version="$(python -c 'import tomllib; print(tomllib.load(open("pyproject.toml", "rb"))["project"]["version"])')"
+            tag="v$version"
+            python -m scripts.release_validate --tag "$tag"
+            git merge-base --is-ancestor HEAD origin/main || {
+              echo "bootstrap commit must be reachable from origin/main" >&2
+              exit 1
+            }
+            mode=bootstrap
+          else
+            tag="$REF_NAME"
+            python -m scripts.release_validate \
+              --tag "$tag" \
+              --require-main-ancestor \
+              --main-ref origin/main
+            version="${tag#v}"
+            mode=release
+          fi
+          echo "mode=$mode" >> "$GITHUB_OUTPUT"
+          echo "version=$version" >> "$GITHUB_OUTPUT"
+
+  quality:
+    needs: validate
+    if: needs.validate.outputs.mode == 'release'
+    uses: ./.github/workflows/quality.yml
+    with:
+      force_docker: true
+
+  bootstrap:
+    needs: validate
+    if: needs.validate.outputs.mode == 'bootstrap'
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: docker/setup-buildx-action@v3
+      - uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+      - name: Publish Bot bootstrap package
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          platforms: linux/amd64
+          push: true
+          tags: ${{ env.BOT_IMAGE }}:bootstrap-amd64
+          build-args: |
+            YUKI_VERSION=${{ needs.validate.outputs.version }}
+            VCS_REF=${{ github.sha }}
+          labels: |
+            org.opencontainers.image.source=https://github.com/${{ github.repository }}
+            org.opencontainers.image.revision=${{ github.sha }}
+            org.opencontainers.image.version=${{ needs.validate.outputs.version }}
+            org.opencontainers.image.licenses=MIT
+      - name: Publish Genie-TTS Worker bootstrap package
+        uses: docker/build-push-action@v6
+        with:
+          context: services/genie_tts_worker
+          platforms: linux/amd64
+          push: true
+          tags: ${{ env.WORKER_IMAGE }}:bootstrap-amd64
+          build-args: |
+            YUKI_VERSION=${{ needs.validate.outputs.version }}
+            VCS_REF=${{ github.sha }}
+          labels: |
+            org.opencontainers.image.source=https://github.com/${{ github.repository }}
+            org.opencontainers.image.revision=${{ github.sha }}
+            org.opencontainers.image.version=${{ needs.validate.outputs.version }}
+            org.opencontainers.image.licenses=MIT
+      - name: Explain required one-time visibility step
+        run: |
+          echo "Bootstrap images were published. In GitHub Packages settings, make both packages Public"
+          echo "before pushing the formal v${{ needs.validate.outputs.version }} tag."
+
+  release:
+    needs: [validate, quality]
+    if: needs.validate.outputs.mode == 'release' && needs.quality.result == 'success'
+    runs-on: ubuntu-latest
+    env:
+      VERSION: ${{ needs.validate.outputs.version }}
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+      - uses: docker/setup-buildx-action@v3
+
+      - name: Build amd64 release images locally
+        shell: bash
+        run: |
+          set -euo pipefail
+          common=(
+            --platform linux/amd64
+            --load
+            --build-arg "YUKI_VERSION=$VERSION"
+            --build-arg "VCS_REF=$GITHUB_SHA"
+            --label "org.opencontainers.image.source=https://github.com/$GITHUB_REPOSITORY"
+            --label "org.opencontainers.image.revision=$GITHUB_SHA"
+            --label "org.opencontainers.image.version=$VERSION"
+            --label "org.opencontainers.image.licenses=MIT"
+          )
+          docker buildx build "${common[@]}" --tag "$BOT_IMAGE:$VERSION" .
+          docker buildx build "${common[@]}" --tag "$WORKER_IMAGE:$VERSION" services/genie_tts_worker
+          for image in "$BOT_IMAGE:$VERSION" "$WORKER_IMAGE:$VERSION"; do
+            test "$(docker image inspect "$image" --format '{{index .Config.Labels "org.opencontainers.image.version"}}')" = "$VERSION"
+            test "$(docker image inspect "$image" --format '{{index .Config.Labels "org.opencontainers.image.revision"}}')" = "$GITHUB_SHA"
+            test "$(docker image inspect "$image" --format '{{index .Config.Labels "org.opencontainers.image.source"}}')" = "https://github.com/$GITHUB_REPOSITORY"
+            test "$(docker image inspect "$image" --format '{{index .Config.Labels "org.opencontainers.image.licenses"}}')" = "MIT"
+          done
+
+      - name: Build tracked allowlist deploy bundle
+        shell: bash
+        run: |
+          set -euo pipefail
+          python -m scripts.build_release_bundle --version "$VERSION" --output-dir dist
+          test "$(find dist -maxdepth 1 -type f | wc -l)" -eq 5
+
+      - name: Run source-free local smoke and persistence checks
+        shell: bash
+        run: |
+          set -euo pipefail
+          smoke_root="$RUNNER_TEMP/yuki-source-free-local"
+          mkdir -p "$smoke_root"
+          unzip -q "dist/yuki-$VERSION-deploy.zip" -d "$smoke_root"
+          deploy_dir="$smoke_root/yuki-$VERSION-deploy"
+          test ! -e "$deploy_dir/src"
+          test ! -e "$deploy_dir/pyproject.toml"
+          python scripts/release_smoke.py --deploy-dir "$deploy_dir" --version "$VERSION" --full
+          echo "DEPLOY_DIR=$deploy_dir" >> "$GITHUB_ENV"
+
+      - uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Push immutable version tags
+        shell: bash
+        run: |
+          set -euo pipefail
+          publish_version() {
+            local image="$1"
+            if docker manifest inspect "$image:$VERSION" >/dev/null 2>&1; then
+              docker pull "$image:$VERSION"
+              revision="$(docker image inspect "$image:$VERSION" --format '{{index .Config.Labels "org.opencontainers.image.revision"}}')"
+              if [[ "$revision" != "$GITHUB_SHA" ]]; then
+                echo "Refusing to overwrite immutable $image:$VERSION from revision $revision" >&2
+                exit 1
+              fi
+              echo "Reusing $image:$VERSION from the same revision"
+            else
+              docker push "$image:$VERSION"
+            fi
+          }
+          publish_version "$BOT_IMAGE"
+          publish_version "$WORKER_IMAGE"
+
+      - name: Verify anonymous version pulls and Bot startup
+        shell: bash
+        run: |
+          set -euo pipefail
+          docker logout ghcr.io
+          docker image rm --force "$BOT_IMAGE:$VERSION" "$WORKER_IMAGE:$VERSION" || true
+          (
+            cd "$DEPLOY_DIR"
+            docker compose --profile speech pull
+          )
+          python scripts/release_smoke.py --deploy-dir "$DEPLOY_DIR" --version "$VERSION"
+
+      - uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Update latest only after public version verification
+        shell: bash
+        run: |
+          set -euo pipefail
+          docker pull "$BOT_IMAGE:$VERSION"
+          docker pull "$WORKER_IMAGE:$VERSION"
+          docker tag "$BOT_IMAGE:$VERSION" "$BOT_IMAGE:latest"
+          docker tag "$WORKER_IMAGE:$VERSION" "$WORKER_IMAGE:latest"
+          docker push "$BOT_IMAGE:latest"
+          docker push "$WORKER_IMAGE:latest"
+
+      - name: Verify public version and latest digests
+        shell: bash
+        run: |
+          set -euo pipefail
+          docker logout ghcr.io
+          docker image rm --force \
+            "$BOT_IMAGE:$VERSION" "$BOT_IMAGE:latest" \
+            "$WORKER_IMAGE:$VERSION" "$WORKER_IMAGE:latest" || true
+          for image in "$BOT_IMAGE" "$WORKER_IMAGE"; do
+            version_digest="$(docker buildx imagetools inspect --raw "$image:$VERSION" | sha256sum | cut -d' ' -f1)"
+            latest_digest="$(docker buildx imagetools inspect --raw "$image:latest" | sha256sum | cut -d' ' -f1)"
+            test "$version_digest" = "$latest_digest"
+          done
+
+      - name: Create or update GitHub Release
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        shell: bash
+        run: |
+          set -euo pipefail
+          tag="v$VERSION"
+          if gh release view "$tag" >/dev/null 2>&1; then
+            gh release edit "$tag" --title "Yuki $VERSION" --notes-file "docs/releases/v$VERSION.md"
+          else
+            gh release create "$tag" --verify-tag --title "Yuki $VERSION" --notes-file "docs/releases/v$VERSION.md"
+          fi
+          gh release upload "$tag" --clobber \
+            "dist/yuki-$VERSION-deploy.zip" \
+            "dist/yuki-$VERSION-deploy.tar.gz" \
+            "dist/docker-compose.yml" \
+            "dist/.env.example" \
+            "dist/Yuki-$VERSION-Upgrade.md"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,19 @@
 
 ## Unreleased
 
+## 3.5.2 - 2026-08-15
+
+### Versioned Docker Release
+
+- 正式发布 `linux/amd64` Bot 与 Genie-TTS Worker GHCR 镜像；两个镜像共享 Yuki `3.5.2`
+  标签和 OCI release metadata，Worker 内部组件版本保持 `1.9.0`。
+- 根 Compose 改用固定版本镜像并移除生产构建；新增开发 Compose 覆盖，源码开发仍可构建本地
+  `dev` 镜像。
+- Release workflow 校验 Tag、包版本、运行时版本、锁文件与 Memory Release Check，复用完整质量
+  门禁，并在推送不可变镜像前执行无源码 Smoke 与持久化检查。
+- GitHub Release 附带白名单生成的部署压缩包、生产 Compose、环境模板和升级说明；普通用户无需
+  安装 Python、uv 或克隆源码即可部署。
+
 ## 3.5.1 - 2026-08-15
 
 ### 自适应记忆生命周期

--- a/Dockerfile
+++ b/Dockerfile
@@ -13,9 +13,16 @@ COPY src ./src
 RUN uv sync --frozen --no-dev --no-editable
 
 FROM python:3.12-slim AS runtime
+ARG YUKI_VERSION=dev
+ARG VCS_REF=unknown
 ENV PATH="/app/.venv/bin:$PATH" \
     PYTHONUNBUFFERED=1 \
     PYTHONDONTWRITEBYTECODE=1
+LABEL org.opencontainers.image.title="Yuki QQ Bot" \
+      org.opencontainers.image.source="https://github.com/YuanYeYouTao/Yuki-QQbot" \
+      org.opencontainers.image.licenses="MIT" \
+      org.opencontainers.image.version="${YUKI_VERSION}" \
+      org.opencontainers.image.revision="${VCS_REF}"
 RUN apt-get update \
     && apt-get install -y --no-install-recommends fonts-wqy-microhei \
     && rm -rf /var/lib/apt/lists/* \

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@
 <p>面向个人部署、以长期关系和长期记忆为核心的 QQ AI Agent</p>
 
 <p>
-  <a href="https://github.com/YuanYeYouTao/Yuki-QQbot/releases/tag/v3.5.1"><img src="https://img.shields.io/badge/Version-3.5.1-orange" alt="Version 3.5.1"></a>
+  <a href="https://github.com/YuanYeYouTao/Yuki-QQbot/releases/tag/v3.5.2"><img src="https://img.shields.io/badge/Version-3.5.2-orange" alt="Version 3.5.2"></a>
   <img src="https://img.shields.io/badge/Python-3.12-3776AB?logo=python&logoColor=white" alt="Python 3.12">
   <img src="https://img.shields.io/badge/NoneBot2-OneBot%20v11-green" alt="NoneBot2 and OneBot v11">
   <img src="https://img.shields.io/badge/Deploy-Docker%20Compose-2496ED?logo=docker&logoColor=white" alt="Docker Compose">
@@ -37,7 +37,7 @@ Yuki 不是把大模型简单接到 QQ 上的问答机器人。它以 NapCatQQ �
 一次 Planner 决策、受控 Agent 工具循环、身份隔离的 Memory V2、持久化自动化和插件系统，
 让一个可自托管的 QQ 角色能够长期对话、记住人与共同经历，并安全地执行外部操作。
 
-项目主要通过 Codex 协作开发，当前稳定版本为 **3.5.1**。它适合愿意自行维护模型配置、QQ
+项目主要通过 Codex 协作开发，当前稳定版本为 **3.5.2**。它适合愿意自行维护模型配置、QQ
 登录态和本地数据的个人用户；不是面向多租户的托管机器人平台。
 
 ## 项目概览
@@ -419,14 +419,13 @@ MCP Client 支持 stdio 和 Streamable HTTP，包含动态发现、元数据缓�
 - Docker Engine / Docker Desktop 与 Docker Compose
 - 一个可登录 NapCatQQ 的 QQ 账号
 - 一个 OpenAI-compatible 模型接口；推荐为 Planner 配置低延迟 Flash 模型
-- 本地开发时需要 Python 3.12 与 [uv](https://docs.astral.sh/uv/)
+- 只有本地开发才需要 Python 3.12、[uv](https://docs.astral.sh/uv/) 和完整源码
 
-### 1. 获取代码
+### 1. 获取部署包
 
-```bash
-git clone https://github.com/YuanYeYouTao/Yuki-QQbot.git
-cd Yuki-QQbot
-```
+从 [Yuki 3.5.2 Release](https://github.com/YuanYeYouTao/Yuki-QQbot/releases/tag/v3.5.2)
+下载 `yuki-3.5.2-deploy.zip` 或 `yuki-3.5.2-deploy.tar.gz` 并解压。正式部署不需要克隆源码，
+也不会在用户机器上构建镜像。
 
 ### 2. 创建配置
 
@@ -461,7 +460,7 @@ LLM_MODEL=你的主模型名称
 ### 3. 启动
 
 ```bash
-docker compose up -d --build
+docker compose up -d
 docker compose ps
 docker compose logs -f bot napcat
 ```
@@ -469,18 +468,27 @@ docker compose logs -f bot napcat
 Bot 容器启动时会自动生成 NapCat OneBot 配置并执行 `alembic upgrade head`。打开
 `http://127.0.0.1:6099` 登录 NapCat，确认反向 WebSocket 已连接后即可在 QQ 中测试。
 
-日常更新 Bot 而保留 NapCat 登录容器：
+升级前先备份 `data/`，再把 `.env` 中的 `YUKI_VERSION` 修改为目标版本：
 
 ```bash
-git pull --ff-only
-docker compose up -d --build --no-deps bot
-docker compose logs -f bot
+docker compose pull
+docker compose up -d
 ```
+
+版本镜像不可变；`docker compose pull` 只拉取 `.env` 当前指定的版本。不要用新部署包直接覆盖
+旧目录，保留现有 `config/`、`plugins/`、`data/` 和 `napcat-*`。完整步骤见
+[3.5.2 升级说明](docs/releases/v3.5.2.md)。
 
 停止全部服务：
 
 ```bash
 docker compose down
+```
+
+本地源码开发使用独立覆盖文件：
+
+```bash
+docker compose -f docker-compose.yml -f docker-compose.dev.yml up -d --build
 ```
 
 ### 4. 可选 Pro / Flash 路由
@@ -614,7 +622,7 @@ GitHub Actions 还会验证 Docker Compose、运行时镜像、隔离的 Genie-T
 ## 文档
 
 - [完整使用帮助](docs/help.md)
-- [3.5.1 发布说明](docs/releases/v3.5.1.md)
+- [3.5.2 发布与升级说明](docs/releases/v3.5.2.md)
 - [Memory V2 架构](docs/architecture/memory-v2.md)
 - [记忆检索与混合 RAG](docs/architecture/memory-v2-retrieval.md)
 - [记忆冲突](docs/architecture/memory-v2-conflicts.md)
@@ -622,6 +630,7 @@ GitHub Actions 还会验证 Docker Compose、运行时镜像、隔离的 Genie-T
 - [记忆变更接口](docs/architecture/memory-change.md)
 - [自适应记忆生命周期](docs/architecture/Yuki_Adaptive_Memory_Lifecycle_Implementation_Plan.md)
 - [Memory 质量与运维](docs/operations/memory-quality.md)
+- [版本化 Docker 发布](docs/operations/versioned-docker-release.md)
 - [受控历史重建](docs/architecture/memory-v2-rebuild.md)
 - [Tool Kernel](docs/architecture/tool-kernel.md)
 - [Plugin 开发](docs/plugin-development/index.md)

--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -1,0 +1,20 @@
+services:
+  bot:
+    image: yuki-qqbot:dev
+    pull_policy: build
+    build:
+      context: .
+      dockerfile: Dockerfile
+      args:
+        YUKI_VERSION: dev
+        VCS_REF: local
+
+  genie-tts-worker:
+    image: yuki-genie-tts-worker:dev
+    pull_policy: build
+    build:
+      context: services/genie_tts_worker
+      dockerfile: Dockerfile
+      args:
+        YUKI_VERSION: dev
+        VCS_REF: local

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -2,9 +2,9 @@ name: qq-ai-bot
 
 services:
   bot:
-    build:
-      context: .
-      dockerfile: Dockerfile
+    image: ghcr.io/yuanyeyoutao/yuki-qqbot:${YUKI_VERSION:?missing}
+    platform: linux/amd64
+    pull_policy: missing
     init: true
     restart: unless-stopped
     env_file:
@@ -42,9 +42,9 @@ services:
 
   genie-tts-worker:
     profiles: ["speech"]
-    build:
-      context: services/genie_tts_worker
-      dockerfile: Dockerfile
+    image: ghcr.io/yuanyeyoutao/yuki-genie-tts-worker:${YUKI_VERSION:?missing}
+    platform: linux/amd64
+    pull_policy: missing
     init: true
     restart: unless-stopped
     network_mode: none

--- a/docs/help.md
+++ b/docs/help.md
@@ -1,5 +1,9 @@
 # Yuki-QQbot
 
+> **3.5.2 正式版：**部署改用固定版本 GHCR 镜像和无源码 Release 部署包；生产 Compose 不再
+> 本地构建 Bot 或语音 Worker。升级时先修改 `.env` 中的 `YUKI_VERSION`，再执行
+> `docker compose pull` 和 `docker compose up -d`。本版本没有新增数据库迁移。
+>
 > **3.5.1 正式版：**新增自适应记忆生命周期。召回使用结构化意图、Activation 衰减与有界强化；
 > 自动召回、显式工具读取和记忆变更使用互斥路径，归因在发送后异步完成。记忆写入由独立
 > mutation 完成门约束，DeepSeek 请求不携带不受支持的 `tool_choice`。Alembic head 为 `0036`。
@@ -75,13 +79,13 @@
 > 只有当前真实 `SUPERUSERS` 发送者显式 plan/start、人工审阅并 commit 后才会写入事实。
 > 进程重启会暂停而不会自动恢复。操作前仍应备份 `data/`。
 
-Plugin API 仍为 `1.0`。第三方插件如果把 `yuki_requires` 上限写成 `<3.0`，需要在确认兼容后
-改为 `<4.0` 才能在 3.0.0a1 加载；插件代码和 manifest 的 `plugin_api` 无需因本次升级改版。
+当前 Plugin API 为 `1.1`，并兼容声明 `1.0` 的插件。第三方插件若把 `yuki_requires` 上限写成
+`<3.0`，需要在确认兼容后改为 `<4.0`；不要根据 Yuki 产品版本猜测 Plugin API 版本。
 
-已经配置好 `.env` 并完成 NapCat 扫码时，在仓库根目录执行：
+从 GitHub Release 解压部署包，复制 `.env.example` 为 `.env` 并填写必要配置，然后执行：
 
 ```bash
-docker compose up -d --build
+docker compose up -d
 docker compose ps
 docker compose logs -f bot napcat
 ```
@@ -95,7 +99,7 @@ docker compose up -d
 语音功能默认关闭，不影响原有纯文字启动。准备好本地 GenieData 和声线后，使用：
 
 ```bash
-docker compose --profile speech up -d --build
+docker compose --profile speech up -d
 ```
 
 停止服务：
@@ -108,7 +112,7 @@ docker compose down
 
 ## 项目定位
 
-Yuki-QQbot 3.5.1 是基于 Python 3.12、NoneBot2、OneBot v11、NapCatQQ、SQLite 和 OpenAI-compatible Chat Completions / Responses API 的人物中心 QQ Agent。
+Yuki-QQbot 3.5.2 是基于 Python 3.12、NoneBot2、OneBot v11、NapCatQQ、SQLite 和 OpenAI-compatible Chat Completions / Responses API 的人物中心 QQ Agent。
 
 - QQ 号字符串是人物的全局唯一身份。
 - 当前消息发送者的 QQ 是否属于 `SUPERUSERS`，是唯一管理员凭证。
@@ -178,7 +182,7 @@ Memory V2 质量、合成大库性能基准与生产审计命令见
 1. 本机运行时复制 `.mcp.json.example` 为 `.mcp.json`；Docker 部署时复制为
    `config/mcp.json`，并在 `.env` 设置 `MCP_CONFIG_PATH=/app/config/mcp.json`。
 2. 在 `.env` 中设置 `MCP_ENABLED=true`；令牌、Cookie 等仅通过 `${ENV_NAME}` 引用。
-3. 重建 Bot：`docker compose up -d --build bot`。不要重建或退出 NapCat，可保留 QQ 登录状态。
+3. 重建 Bot：`docker compose up -d --no-deps --force-recreate bot`。不要重建或退出 NapCat，可保留 QQ 登录状态。
 4. 用 `/ai mcp list` 查看状态；超级管理员可执行 `/ai mcp doctor <server_id>`。
 
 `MCP_TOOL_SELECTION_MODE=hybrid` 会先做本地目录粗选，再由 `TOOL_SELECTION` 的 Flash
@@ -429,7 +433,7 @@ VISION_LOW_CONFIDENCE_RETRY_THRESHOLD=0.65
 然后重建 Bot 容器：
 
 ```bash
-docker compose up -d --build --no-deps bot
+docker compose up -d --no-deps --force-recreate bot
 docker compose logs -f bot
 ```
 
@@ -449,7 +453,7 @@ DEFAULT_TIMEZONE=Asia/Shanghai
 然后只重建 Bot：
 
 ```bash
-docker compose up -d --build --no-deps bot
+docker compose up -d --no-deps --force-recreate bot
 ```
 
 普通用户可以创建提醒、定时生成文本、给自己发私聊，以及在创建消息所在的当前群执行受限任务；只能查看、修改和运行本人任务。超级管理员可以额外委托已登记的管理员业务接口、运行时配置和 NapCat/OneBot 全部公开 action。引用、历史、记忆、网页、OCR 和模型自行生成的 QQ/群号不能扩大目标范围。
@@ -610,7 +614,7 @@ docker compose up -d --build
 `PLUGIN_SYSTEM_ENABLED=true`，批准插件并只重启 Bot：
 
 ```bash
-docker compose up -d --build --no-deps bot
+docker compose up -d --no-deps --force-recreate bot
 docker compose exec bot qq-ai-bot-cli plugin discover
 docker compose exec bot qq-ai-bot-cli plugin inspect io.github.yuanyeyoutao.netease-music-card
 docker compose exec bot qq-ai-bot-cli plugin approve io.github.yuanyeyoutao.netease-music-card
@@ -1066,7 +1070,7 @@ WEB_SEARCH_DEPTH=advanced
 然后只重建 Bot 容器：
 
 ```bash
-docker compose up -d --build --no-deps bot
+docker compose up -d --no-deps --force-recreate bot
 ```
 
 配置规则：
@@ -1458,9 +1462,14 @@ Docker 验证：
 
 ```bash
 docker compose config
-docker compose build bot
 docker compose up -d
 docker compose ps
+```
+
+源码开发构建验证：
+
+```bash
+docker compose -f docker-compose.yml -f docker-compose.dev.yml build bot
 ```
 
 健康检查不会请求 DeepSeek、Planner、Tavily、Qwen 或执行真实自动化，也不会暴露密钥；`planner_enabled/configured/active_requests`、`plugin_system_enabled/running_count`、`web_configured`、`vision_configured`、`automation_worker_running`、`active_automation_count`、`mcp_automation_tools` 和 `mcp_automation_missing_tools` 都只读取本地配置或运行状态：
@@ -1491,7 +1500,7 @@ docker compose exec bot python -c "import urllib.request; print(urllib.request.u
 3. 对照最新 `.env.example`；本次没有新增密钥，Memory V2 沿用现有容量与批处理配置。
 4. 执行 `uv run alembic upgrade head` 到 `0020`。该操作会永久删除全部旧记忆、偏好和旧记忆
    任务，但保留人物、群、聊天事件、关系、自动化和插件数据。
-5. 执行 `docker compose up -d --build --no-deps bot`；只重建 Bot，NapCat 和 QQ 登录态不变。
+5. 执行 `docker compose up -d --no-deps --force-recreate bot`；只重建 Bot，NapCat 和 QQ 登录态不变。
 6. 检查 `docker compose ps`、`/healthz` 和日志，再验证私聊、群聊 @、记忆命令和插件。
 
 `0020` 不支持 downgrade，不会自动从 2.1.2 记忆或历史聊天重建事实。唯一回退方式是停止服务
@@ -1502,7 +1511,7 @@ docker compose exec bot python -c "import urllib.request; print(urllib.request.u
 1. 停止 Bot 写入但保持 NapCat 登录态：`docker compose stop bot`。
 2. 备份 `data/` 后执行 `uv run alembic upgrade head`，升级到 `0021`。
 3. `0021` 会从现有 `memory_facts` 回填 FTS5；不会读取旧版记忆或扫描聊天历史。
-4. 执行 `docker compose up -d --build --no-deps bot`，再用 `/ai memory index status` 检查索引。
+4. 执行 `docker compose up -d --no-deps --force-recreate bot`，再用 `/ai memory index status` 检查索引。
 
 本次 downgrade 只会删除 FTS 表和触发器，不删除 Memory V2 facts 或 evidence。索引异常时使用
 `/ai memory index rebuild` 重建派生数据，不需要删除数据库。
@@ -1514,7 +1523,7 @@ docker compose exec bot python -c "import urllib.request; print(urllib.request.u
 3. 若暂不使用语义检索，保持 `MEMORY_EMBEDDING_ENABLED=false` 即可；行为与 3.0.0a2 一致。
 4. 若要启用，在 `.env` 设置 `MEMORY_EMBEDDING_ENABLED=true`、DashScope 兼容端点和
    `MEMORY_EMBEDDING_API_KEY`。密钥只从环境读取，不会进入数据库或诊断输出。
-5. 执行 `docker compose up -d --build --no-deps bot`，再运行
+5. 执行 `docker compose up -d --no-deps --force-recreate bot`，再运行
    `/ai memory embedding status` 和 `/ai memory embedding doctor`。
 
 `0022` 不修改 Memory V2 事实、证据、FTS 或聊天账本。首次启用后由持久后台任务渐进补齐当前
@@ -1527,7 +1536,7 @@ docker compose exec bot python -c "import urllib.request; print(urllib.request.u
 2. 完整备份 `data/`，然后执行 `uv run alembic upgrade head`，确认 head 为 `0023`。
 3. 对照 `.env.example` 补充 Memory consolidation、evidence 和 maintenance 配置；这些项目不含
    新密钥，默认路由到已有 Flash 模型档案。
-4. 执行 `docker compose up -d --build --no-deps bot`，检查 `/healthz`、
+4. 执行 `docker compose up -d --no-deps --force-recreate bot`，检查 `/healthz`、
    `/ai memory doctor` 和 `/ai memory maintenance status`。
 5. 分别验证本人修正、群内真实 @ 第三方事实、矛盾陈述、撤回与恢复；确认 NapCat 登录态不变。
 
@@ -1540,7 +1549,7 @@ docker compose exec bot python -c "import urllib.request; print(urllib.request.u
 1. 只停止 Bot：`docker compose stop bot`，不要停止或重建 NapCat。
 2. 完整备份 `data/`，执行 `uv run alembic upgrade head`，确认 head 为 `0024`。
 3. 默认保持 `MEMORY_REBUILD_ENABLED=false`；这不会创建、启动或恢复任何重建任务。
-4. 需要重建时再设为 `true` 并只重建 Bot：`docker compose up -d --build --no-deps bot`。
+4. 需要重建时再设为 `true` 并只重建 Bot：`docker compose up -d --no-deps --force-recreate bot`。
 5. 由当前真实超级管理员先执行 plan，确认统计后 start；提取完成必须 review 并逐项批准或拒绝，
    pending 为 0 后才可 commit。
 
@@ -1561,7 +1570,7 @@ uv run qq-ai-bot-cli memory quality run --suite full
 uv run qq-ai-bot-cli memory quality compare
 uv run qq-ai-bot-cli memory quality performance
 uv run qq-ai-bot-cli memory release-check
-docker compose up -d --build --no-deps bot
+docker compose -f docker-compose.yml -f docker-compose.dev.yml up -d --build --no-deps bot
 ```
 
 需要审计真实 SQLite 时必须显式传 `--database-url`；命令只读且不自动治理。完整结果见

--- a/docs/operations/versioned-docker-release.md
+++ b/docs/operations/versioned-docker-release.md
@@ -1,0 +1,41 @@
+# Versioned Docker Release 运维说明
+
+Yuki 3.5.2 的正式镜像只由 `.github/workflows/release.yml` 发布，目标平台为
+`linux/amd64`。本地开发镜像不属于发布合同。
+
+## 首次 GHCR Bootstrap
+
+正式 Tag 前只执行一次：
+
+1. 在 GitHub Actions 打开 `Release`，对最新 `main` 运行 `workflow_dispatch`。
+2. 工作流只发布两个 `bootstrap-amd64` 标签，用于创建 Bot 与 Genie-TTS Worker Package。
+3. 在仓库所有者的 GitHub Packages 设置中，把两个 Package 的 visibility 改为 **Public**。
+4. 在未登录 GHCR 的环境确认两个 bootstrap 镜像可拉取。
+
+公开 Package 才能让普通用户匿名执行 `docker compose pull`。Bootstrap 不创建正式 Release，
+也不发布 `3.5.2` 或 `latest`。
+
+## 正式发布
+
+1. 确认 `main` 中根 `pyproject.toml`、运行时 `__version__`、根 `uv.lock` 和 Memory Release
+   Check 均为同一版本；Worker 内部组件版本保持 `1.9.0`。
+2. 确认 Quality workflow 通过。
+3. 在 `main` 可达提交创建严格 `vX.Y.Z` Tag 并推送。
+4. Release workflow 会强制重跑完整 Quality，构建本地 amd64 镜像和部署包，并在无源码目录
+   检查 Bot、Alembic、Worker、挂载与容器重建。
+5. Smoke 通过后才推送不可变版本标签。匿名版本拉取和 Bot 启动通过后才更新 `latest`，最后
+   校验 digest 并创建 GitHub Release。
+
+若同一版本标签已存在，只有 OCI `org.opencontainers.image.revision` 等于当前 Tag SHA 才允许
+失败重跑；其他 revision 永远不会被覆盖。Release 资产可在同 Tag 下安全 `--clobber` 重传。
+
+## 用户升级合同
+
+正式部署在 `.env` 固定 `YUKI_VERSION`。跨版本升级先修改版本，再执行：
+
+```bash
+docker compose pull
+docker compose up -d
+```
+
+不要用新部署包覆盖旧目录；保留并备份 `data/`、`config/`、`plugins/` 和 `napcat-*`。

--- a/docs/plugin-development/debugging.md
+++ b/docs/plugin-development/debugging.md
@@ -31,9 +31,8 @@ uv run qq-ai-bot-cli plugin test plugins/com.example.plugin
 
 ```bash
 docker compose config
-docker compose up -d --build --no-deps bot
+docker compose up -d --no-deps --force-recreate bot
 docker compose logs -f bot
 ```
 
 确认 `./plugins:/app/plugins:ro` 已挂载，`.env` 中 `PLUGIN_DIRECTORY=plugins`。插件代码变化目前需要重启 Bot；1.6.0 不提供热更新。
-

--- a/docs/plugin-development/index.md
+++ b/docs/plugin-development/index.md
@@ -50,7 +50,7 @@ Yuki 3.4.1 将 Plugin API 扩展为 `1.1`，新增受 Host 管理的后台服务
 
 | 标识 | 当前值 | 用途 |
 |---|---:|---|
-| Yuki | `3.5.1` | Host 产品版本 |
+| Yuki | `3.5.2` | Host 产品版本 |
 | Plugin API | `1.1` | SDK 主兼容边界 |
 | Event/Tool/Automation Schema | `1` | 单类载荷的结构版本 |
 | Feature | 如 `planner.signal.v1` | 运行时能力探测 |

--- a/docs/plugin-development/migration-guide.md
+++ b/docs/plugin-development/migration-guide.md
@@ -36,7 +36,8 @@ Host 的 Alembic `0013` 非破坏性创建 Planner、插件安装/配置/KV/审�
 ```bash
 docker compose down
 cp -R data data.backup-1.6.0
-docker compose up -d --build
+docker compose pull
+docker compose up -d
 ```
 
 首次升级可设置 `PLUGIN_SYSTEM_ENABLED=false`，先检查数据库和普通聊天，再逐项启用插件。Planner 是普通聊天的固定调度边界，不再提供旧流程回退开关。

--- a/docs/plugin-development/quickstart.md
+++ b/docs/plugin-development/quickstart.md
@@ -115,7 +115,7 @@ Manifest 哈希绑定批准状态。只要权限、入口、版本或其他 Mani
 Docker 部署默认把宿主的 `./plugins` 只读挂载到 `/app/plugins`：
 
 ```bash
-docker compose up -d --build --no-deps bot
+docker compose up -d --no-deps --force-recreate bot
 docker compose logs -f bot
 ```
 

--- a/docs/releases/v3.5.2.md
+++ b/docs/releases/v3.5.2.md
@@ -1,0 +1,57 @@
+# Yuki 3.5.2 发布与升级说明
+
+Yuki 3.5.2 将正式部署入口改为版本化 Docker 镜像。本版本不改变 Agent、Memory、Plugin API
+或数据库结构；Alembic head 仍为 `0036`，Plugin API 仍为 `1.1`。
+
+## 新安装
+
+1. 从 GitHub Release 下载 `yuki-3.5.2-deploy.zip` 或 `yuki-3.5.2-deploy.tar.gz` 并解压。
+2. 进入解压目录，复制环境模板：`cp .env.example .env`。
+3. 在 `.env` 中填写 OneBot、管理员和模型配置；保留 `YUKI_VERSION=3.5.2`。
+4. 执行 `docker compose up -d`。
+5. 打开 `http://127.0.0.1:6099` 完成 NapCat 登录，并检查 `docker compose ps`。
+
+部署包不包含源码、数据库、密钥或本机配置。Bot 启动时会自动把空数据库迁移到 Alembic
+`0036`。
+
+## 从旧版本升级
+
+不要把新部署包直接解压覆盖现有目录。升级前：
+
+1. 备份整个 `data/`，并保留现有 `config/`、`plugins/`、`napcat-data/`、`napcat-config/` 和
+   `napcat-plugins/`。
+2. 从 Release 单独下载新的 `docker-compose.yml` 和 `.env.example`，人工合并必要环境变量。
+3. 把现有 `.env` 的 `YUKI_VERSION` 改为 `3.5.2`。
+4. 执行：
+
+   ```bash
+   docker compose pull
+   docker compose up -d
+   docker compose ps
+   ```
+
+5. 检查 `docker compose logs --tail 200 bot`，并确认 `/healthz` 返回 `status=ok`、
+   `version=3.5.2` 和 `database=ok`。
+
+`docker compose pull` 只拉取 Compose 当前指定的镜像。正式部署应使用不可变版本号；`latest`
+仅供快速体验，不是生产默认值。不要执行 `docker compose down -v`。
+
+## 可选语音 Worker
+
+GenieData 和声线仍由用户放在持久化语音目录中，不会打入镜像。准备完成后执行：
+
+```bash
+docker compose --profile speech up -d
+```
+
+Yuki 镜像标签为 `3.5.2`，但 Genie-TTS Worker 的内部组件版本继续保持 `1.9.0`。
+
+## 本地源码开发
+
+开发环境才使用构建覆盖：
+
+```bash
+docker compose -f docker-compose.yml -f docker-compose.dev.yml up -d --build
+```
+
+生产 `docker-compose.yml` 不包含任何 `build:`。

--- a/docs/speech/genie-worker.md
+++ b/docs/speech/genie-worker.md
@@ -9,7 +9,7 @@ load/reload/unload profile、synthesize、cancel、clear reference cache 和 shu
 合成先写临时文件，校验 WAV 参数后原子替换。Socket 权限默认 `0660`。
 
 ```bash
-docker compose --profile speech build genie-tts-worker
+docker compose --profile speech pull genie-tts-worker
 docker compose --profile speech up -d genie-tts-worker
 docker compose logs -f genie-tts-worker
 ```

--- a/docs/speech/operations.md
+++ b/docs/speech/operations.md
@@ -4,7 +4,8 @@
 `SPEECH_DEFAULT_PROFILE=<id>`，再启动：
 
 ```bash
-docker compose --profile speech up -d --build
+docker compose --profile speech pull
+docker compose --profile speech up -d
 docker compose ps
 docker compose logs -f bot genie-tts-worker
 qq-ai-bot-cli speech status

--- a/docs/upgrade-memory-v2.md
+++ b/docs/upgrade-memory-v2.md
@@ -14,7 +14,7 @@ Alembic `0020` 不提供 downgrade，也不迁移、导入或双写旧记忆。�
 2. 完整复制仓库的 `data/` 到仓库外或带时间戳的备份目录，并确认数据库文件已复制。
 3. 拉取代码后对照 `.env.example`；本次没有新增密钥。
 4. 执行 `uv run alembic upgrade head`，确认版本为 `0026`。
-5. 执行 `docker compose up -d --build bot`，只重建 bot 可保留 NapCat 登录状态。
+5. 执行 `docker compose up -d --no-deps --force-recreate bot`，只重建 bot 可保留 NapCat 登录状态。
 6. 检查 `/healthz`、bot 日志和一轮私聊/群聊；新记忆应从空库开始产生。
 
 ## 3.0.0b1 增量升级
@@ -37,7 +37,7 @@ docker compose stop bot
 # 先把 data/ 复制到带时间戳的备份目录
 uv run alembic upgrade head
 uv run alembic current
-docker compose up -d --build --no-deps bot
+docker compose up -d --no-deps --force-recreate bot
 ```
 
 升级后运行 `/ai memory doctor` 与 `/ai memory maintenance status`。没有 contested fact 时，
@@ -53,7 +53,7 @@ docker compose up -d --build --no-deps bot
 docker compose stop bot
 Copy-Item data data-backup-before-3.0.0rc1 -Recurse
 uv run alembic upgrade head
-docker compose up -d --build --no-deps bot
+docker compose up -d --no-deps --force-recreate bot
 ```
 
 默认 `MEMORY_REBUILD_ENABLED=false`。即使设为 true，也只表示管理员可以使用该功能：迁移、启动、
@@ -87,7 +87,7 @@ docker compose stop bot
 Copy-Item data data-backup-before-0025 -Recurse
 uv run alembic upgrade head
 uv run alembic current
-docker compose up -d --build --no-deps bot
+docker compose up -d --no-deps --force-recreate bot
 ```
 
 回执与事实写入处于同一事务。Embedding 调度发生在提交之后；调度失败不会回滚已提交事实，

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "qq-ai-bot"
-version = "3.5.1"
+version = "3.5.2"
 description = "基于 NoneBot2、OneBot v11 与 NapCatQQ 的个人 QQ AI 聊天机器人"
 readme = "README.md"
 requires-python = ">=3.12,<3.13"

--- a/scripts/__init__.py
+++ b/scripts/__init__.py
@@ -1,0 +1,1 @@
+"""Repository maintenance scripts."""

--- a/scripts/build_release_bundle.py
+++ b/scripts/build_release_bundle.py
@@ -1,0 +1,187 @@
+"""Build source-free deployment archives from a tracked-file allowlist."""
+
+from __future__ import annotations
+
+import argparse
+import gzip
+import os
+import shutil
+import stat
+import subprocess
+import tarfile
+import tempfile
+import zipfile
+from collections.abc import Iterable
+from pathlib import Path, PurePosixPath
+
+from scripts.release_validate import project_version
+
+_ROOT_FILES = frozenset({"docker-compose.yml", ".env.example"})
+_CONFIG_FILES = frozenset(
+    {
+        "config/memory_contracts.toml",
+        "config/memory_quality_gates.example.toml",
+        "config/memory_quality_gates.toml",
+        "config/model_profiles.example.toml",
+        "config/persona.md",
+        "config/qq_face_map.json",
+        "config/system_prompt.example.md",
+    }
+)
+_EMPTY_DIRECTORIES = (
+    "data",
+    "data/speech/cache",
+    "data/speech/genie_data",
+    "data/speech/voices",
+    "data/speech/japanese_frontend/models",
+    "plugins",
+    "napcat-data",
+    "napcat-config",
+    "napcat-plugins",
+)
+_FORBIDDEN_NAMES = frozenset(
+    {
+        ".env",
+        "model_profiles.toml",
+        "system_prompt.md",
+        "mcp.json",
+        "qq_ai_bot.db",
+    }
+)
+
+
+class BundleBuildError(ValueError):
+    """Raised when the deployment bundle would violate its allowlist."""
+
+
+def tracked_files(root: Path) -> set[str]:
+    completed = subprocess.run(["git", "ls-files", "-z"], cwd=root, check=True, capture_output=True)
+    return {item.decode("utf-8") for item in completed.stdout.split(b"\0") if item}
+
+
+def select_bundle_files(files: Iterable[str], version: str) -> dict[str, str]:
+    tracked = set(files)
+    release_note = f"docs/releases/v{version}.md"
+    required = _ROOT_FILES | _CONFIG_FILES | {release_note}
+    missing = sorted(required - tracked)
+    if missing:
+        raise BundleBuildError(f"required tracked deployment files are missing: {missing}")
+
+    selected = {path: path for path in required - {release_note}}
+    selected[release_note] = f"Yuki-{version}-Upgrade.md"
+    for path in sorted(tracked):
+        pure = PurePosixPath(path)
+        if pure.parts[:1] == ("plugins",):
+            if "tests" in pure.parts or "__pycache__" in pure.parts or pure.suffix == ".pyc":
+                continue
+            selected[path] = path
+        if path == "data/.gitkeep" or path.startswith("data/speech/japanese_frontend/"):
+            if "__pycache__" not in pure.parts and pure.suffix != ".pyc":
+                selected[path] = path
+    _validate_selected_paths(selected.values())
+    return selected
+
+
+def _validate_selected_paths(paths: Iterable[str]) -> None:
+    for path in paths:
+        pure = PurePosixPath(path)
+        if pure.is_absolute() or ".." in pure.parts:
+            raise BundleBuildError(f"unsafe bundle path: {path}")
+        if any(part in _FORBIDDEN_NAMES for part in pure.parts):
+            raise BundleBuildError(f"forbidden bundle path: {path}")
+        if "__pycache__" in pure.parts or pure.suffix == ".pyc":
+            raise BundleBuildError(f"cache file selected for bundle: {path}")
+
+
+def build_release_bundle(
+    root: Path,
+    output_directory: Path,
+    version: str,
+    *,
+    tracked: set[str] | None = None,
+) -> list[Path]:
+    if project_version(root) != version:
+        raise BundleBuildError(
+            f"requested bundle version {version} does not match project {project_version(root)}"
+        )
+    selected = select_bundle_files(tracked if tracked is not None else tracked_files(root), version)
+    output_directory.mkdir(parents=True, exist_ok=True)
+    archive_root_name = f"yuki-{version}-deploy"
+    epoch = int(os.getenv("SOURCE_DATE_EPOCH", "0"))
+
+    with tempfile.TemporaryDirectory(prefix="yuki-release-") as temp_name:
+        archive_root = Path(temp_name) / archive_root_name
+        archive_root.mkdir()
+        for source_path, destination_path in selected.items():
+            source = root / source_path
+            destination = archive_root / destination_path
+            destination.parent.mkdir(parents=True, exist_ok=True)
+            shutil.copyfile(source, destination)
+        for directory in _EMPTY_DIRECTORIES:
+            (archive_root / directory).mkdir(parents=True, exist_ok=True)
+
+        zip_path = output_directory / f"{archive_root_name}.zip"
+        tar_path = output_directory / f"{archive_root_name}.tar.gz"
+        _write_zip(archive_root, zip_path, epoch)
+        _write_tar_gz(archive_root, tar_path, epoch)
+
+    compose_asset = output_directory / "docker-compose.yml"
+    env_asset = output_directory / ".env.example"
+    upgrade_asset = output_directory / f"Yuki-{version}-Upgrade.md"
+    shutil.copyfile(root / "docker-compose.yml", compose_asset)
+    shutil.copyfile(root / ".env.example", env_asset)
+    shutil.copyfile(root / f"docs/releases/v{version}.md", upgrade_asset)
+    return [zip_path, tar_path, compose_asset, env_asset, upgrade_asset]
+
+
+def _write_zip(archive_root: Path, destination: Path, epoch: int) -> None:
+    timestamp = max(epoch, 315532800)
+    date_time = tuple(__import__("time").gmtime(timestamp)[:6])
+    with zipfile.ZipFile(destination, "w", compression=zipfile.ZIP_DEFLATED) as archive:
+        for path in _archive_paths(archive_root):
+            relative = path.relative_to(archive_root.parent).as_posix()
+            name = f"{relative}/" if path.is_dir() else relative
+            info = zipfile.ZipInfo(name, date_time=date_time)
+            info.compress_type = zipfile.ZIP_DEFLATED
+            mode = (stat.S_IFDIR | 0o755) if path.is_dir() else (stat.S_IFREG | 0o644)
+            info.external_attr = mode << 16
+            archive.writestr(info, b"" if path.is_dir() else path.read_bytes())
+
+
+def _write_tar_gz(archive_root: Path, destination: Path, epoch: int) -> None:
+    with destination.open("wb") as raw_handle:
+        with gzip.GzipFile(fileobj=raw_handle, mode="wb", mtime=epoch) as gzip_handle:
+            with tarfile.open(fileobj=gzip_handle, mode="w") as archive:
+                for path in _archive_paths(archive_root):
+                    relative = path.relative_to(archive_root.parent).as_posix()
+                    info = archive.gettarinfo(str(path), arcname=relative)
+                    info.uid = 0
+                    info.gid = 0
+                    info.uname = ""
+                    info.gname = ""
+                    info.mtime = epoch
+                    if path.is_dir():
+                        archive.addfile(info)
+                    else:
+                        with path.open("rb") as handle:
+                            archive.addfile(info, handle)
+
+
+def _archive_paths(root: Path) -> list[Path]:
+    return [root, *sorted(root.rglob("*"), key=lambda item: item.as_posix())]
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--version", required=True)
+    parser.add_argument("--output-dir", type=Path, required=True)
+    parser.add_argument("--root", type=Path, default=Path(__file__).resolve().parents[1])
+    args = parser.parse_args()
+    assets = build_release_bundle(args.root.resolve(), args.output_dir.resolve(), args.version)
+    for asset in assets:
+        print(asset)
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/release_smoke.py
+++ b/scripts/release_smoke.py
@@ -1,0 +1,208 @@
+"""Run source-free production Compose smoke and persistence checks."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import shutil
+import sqlite3
+import subprocess
+import time
+from pathlib import Path
+from typing import Any
+
+
+class SmokeError(RuntimeError):
+    """Raised when a release image or deployment contract fails smoke testing."""
+
+
+class Compose:
+    def __init__(self, deploy_directory: Path, project: str, version: str) -> None:
+        self.deploy_directory = deploy_directory
+        self.environment = os.environ.copy()
+        self.environment["YUKI_VERSION"] = version
+        self.command = ["docker", "compose", "--project-name", project]
+
+    def run(self, *arguments: str, capture: bool = False) -> str:
+        completed = subprocess.run(
+            [*self.command, *arguments],
+            cwd=self.deploy_directory,
+            env=self.environment,
+            check=True,
+            capture_output=capture,
+            text=True,
+        )
+        return completed.stdout.strip() if capture else ""
+
+
+def validate_production_compose(deploy_directory: Path, version: str, compose: Compose) -> None:
+    raw = (deploy_directory / "docker-compose.yml").read_text(encoding="utf-8")
+    if "build:" in raw:
+        raise SmokeError("production Compose must not contain build")
+    rendered = json.loads(
+        compose.run("--profile", "speech", "config", "--format", "json", capture=True)
+    )
+    services: dict[str, dict[str, Any]] = rendered["services"]
+    expected = {
+        "bot": f"ghcr.io/yuanyeyoutao/yuki-qqbot:{version}",
+        "genie-tts-worker": f"ghcr.io/yuanyeyoutao/yuki-genie-tts-worker:{version}",
+    }
+    for service, image in expected.items():
+        if services[service]["image"] != image:
+            raise SmokeError(
+                f"{service} resolved to {services[service]['image']}, expected {image}"
+            )
+        if services[service].get("platform") != "linux/amd64":
+            raise SmokeError(f"{service} does not resolve to linux/amd64")
+    required_mounts = {
+        "bot": {"/app/data", "/app/config", "/app/plugins", "/app/napcat-config"},
+        "genie-tts-worker": {
+            "/data/speech/genie_data",
+            "/data/speech/voices",
+            "/data/speech/cache",
+            "/data/speech/japanese_frontend",
+            "/run/yuki-speech",
+        },
+        "napcat": {"/app/.config/QQ", "/app/napcat/config", "/app/napcat/plugins"},
+    }
+    for service, destinations in required_mounts.items():
+        actual = {mount["target"] for mount in services[service]["volumes"]}
+        if not destinations <= actual:
+            raise SmokeError(f"{service} is missing persistent mounts: {destinations - actual}")
+
+
+def prepare_deployment(deploy_directory: Path) -> dict[Path, str]:
+    env_file = deploy_directory / ".env"
+    if not env_file.exists():
+        shutil.copyfile(deploy_directory / ".env.example", env_file)
+    sentinels = {
+        deploy_directory / "data/.release-smoke-data": "data",
+        deploy_directory / "config/.release-smoke-config": "config",
+        deploy_directory / "plugins/.release-smoke-plugin": "plugins",
+        deploy_directory / "napcat-data/.release-smoke-login": "napcat-login",
+        deploy_directory / "napcat-config/.release-smoke-config": "napcat-config",
+        deploy_directory / "napcat-plugins/.release-smoke-plugin": "napcat-plugins",
+        deploy_directory / "data/speech/genie_data/.release-smoke": "offline-sentinel",
+    }
+    for path, value in sentinels.items():
+        path.parent.mkdir(parents=True, exist_ok=True)
+        path.write_text(value, encoding="utf-8")
+    return sentinels
+
+
+def wait_healthy(compose: Compose, service: str, timeout_seconds: float = 120.0) -> str:
+    container_id = compose.run("ps", "--quiet", service, capture=True)
+    if not container_id:
+        raise SmokeError(f"{service} container was not created")
+    deadline = time.monotonic() + timeout_seconds
+    while time.monotonic() < deadline:
+        status = subprocess.run(
+            ["docker", "inspect", "--format", "{{.State.Health.Status}}", container_id],
+            check=True,
+            capture_output=True,
+            text=True,
+        ).stdout.strip()
+        if status == "healthy":
+            return container_id
+        if status == "unhealthy":
+            raise SmokeError(f"{service} became unhealthy")
+        time.sleep(2)
+    raise SmokeError(f"{service} did not become healthy within {timeout_seconds:.0f}s")
+
+
+def verify_bot(compose: Compose, deploy_directory: Path, version: str) -> None:
+    wait_healthy(compose, "bot")
+    command = (
+        "import json,urllib.request; "
+        "print(json.dumps(json.load(urllib.request.urlopen("
+        "'http://127.0.0.1:8080/healthz', timeout=3))))"
+    )
+    health = json.loads(compose.run("exec", "-T", "bot", "python", "-c", command, capture=True))
+    expected = {"status": "ok", "version": version, "database": "ok"}
+    actual = {key: health.get(key) for key in expected}
+    if actual != expected:
+        raise SmokeError(f"unexpected /healthz response: {actual}")
+    database = deploy_directory / "data/qq_ai_bot.db"
+    with sqlite3.connect(database) as connection:
+        row = connection.execute("SELECT version_num FROM alembic_version").fetchone()
+    if row != ("0036",):
+        raise SmokeError(f"unexpected Alembic version: {row}")
+
+
+def verify_persistence(
+    compose: Compose, deploy_directory: Path, sentinels: dict[Path, str]
+) -> None:
+    database = deploy_directory / "data/qq_ai_bot.db"
+    database_size = database.stat().st_size
+    compose.run("up", "-d", "--no-deps", "--force-recreate", "bot")
+    wait_healthy(compose, "bot")
+    compose.run(
+        "--profile", "speech", "up", "-d", "--no-deps", "--force-recreate", "genie-tts-worker"
+    )
+    wait_healthy(compose, "genie-tts-worker")
+    if not database.exists() or database.stat().st_size < database_size:
+        raise SmokeError("database did not survive container recreation")
+    for path, value in sentinels.items():
+        if path.read_text(encoding="utf-8") != value:
+            raise SmokeError(f"persistent sentinel did not survive recreation: {path}")
+
+
+def verify_napcat_mount_recreation(compose: Compose, deploy_directory: Path) -> None:
+    compose.run("pull", "napcat")
+    for attempt in range(2):
+        compose.run("create", "--pull", "never", "napcat")
+        container_id = compose.run("ps", "--all", "--quiet", "napcat", capture=True)
+        mounts = json.loads(
+            subprocess.run(
+                ["docker", "inspect", "--format", "{{json .Mounts}}", container_id],
+                check=True,
+                capture_output=True,
+                text=True,
+            ).stdout
+        )
+        login_mount = next(
+            (mount for mount in mounts if mount["Destination"] == "/app/.config/QQ"), None
+        )
+        if login_mount is None:
+            raise SmokeError("NapCat login directory is not mounted")
+        if Path(login_mount["Source"]).resolve() != (deploy_directory / "napcat-data").resolve():
+            raise SmokeError("NapCat login mount points outside the deployment directory")
+        if attempt == 0:
+            compose.run("rm", "-s", "-f", "napcat")
+    sentinel = deploy_directory / "napcat-data/.release-smoke-login"
+    if sentinel.read_text(encoding="utf-8") != "napcat-login":
+        raise SmokeError("NapCat login sentinel did not survive container recreation")
+
+
+def run_smoke(deploy_directory: Path, version: str, *, full: bool) -> None:
+    if (deploy_directory / "src").exists() or (deploy_directory / "pyproject.toml").exists():
+        raise SmokeError("deployment smoke directory contains project source")
+    compose = Compose(deploy_directory, f"yuki-release-smoke-{os.getpid()}", version)
+    sentinels = prepare_deployment(deploy_directory)
+    try:
+        validate_production_compose(deploy_directory, version, compose)
+        compose.run("up", "-d", "--no-deps", "bot")
+        verify_bot(compose, deploy_directory, version)
+        if full:
+            compose.run("--profile", "speech", "up", "-d", "--no-deps", "genie-tts-worker")
+            wait_healthy(compose, "genie-tts-worker")
+            verify_persistence(compose, deploy_directory, sentinels)
+            verify_napcat_mount_recreation(compose, deploy_directory)
+    finally:
+        compose.run("--profile", "speech", "down", "--volumes", "--remove-orphans")
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--deploy-dir", type=Path, required=True)
+    parser.add_argument("--version", required=True)
+    parser.add_argument("--full", action="store_true")
+    args = parser.parse_args()
+    run_smoke(args.deploy_dir.resolve(), args.version, full=args.full)
+    print(f"source-free smoke passed for Yuki {args.version}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/release_validate.py
+++ b/scripts/release_validate.py
@@ -1,0 +1,148 @@
+"""Validate the immutable Yuki release identity before expensive CI work."""
+
+from __future__ import annotations
+
+import argparse
+import os
+import re
+import subprocess
+import tomllib
+from pathlib import Path
+
+_TAG_PATTERN = re.compile(r"^v(?P<version>0|[1-9]\d*)\.(0|[1-9]\d*)\.(0|[1-9]\d*)$")
+_APP_VERSION_PATTERN = re.compile(r'^__version__\s*=\s*"([^"]+)"$', re.MULTILINE)
+_RELEASE_VERSION_PATTERN = re.compile(r'^_EXPECTED_RELEASE_VERSION\s*=\s*"([^"]+)"$', re.MULTILINE)
+_ALEMBIC_HEAD_PATTERN = re.compile(r'^_ALEMBIC_HEAD\s*=\s*"([^"]+)"$', re.MULTILINE)
+_PLUGIN_API_PATTERN = re.compile(r'^PLUGIN_API_VERSION\s*=\s*"([^"]+)"$', re.MULTILINE)
+
+
+class ReleaseValidationError(ValueError):
+    """Raised when a release identity or invariant is inconsistent."""
+
+
+def _match_value(path: Path, pattern: re.Pattern[str], label: str) -> str:
+    match = pattern.search(path.read_text(encoding="utf-8"))
+    if match is None:
+        raise ReleaseValidationError(f"could not read {label} from {path}")
+    return match.group(1)
+
+
+def project_version(root: Path) -> str:
+    with (root / "pyproject.toml").open("rb") as handle:
+        return str(tomllib.load(handle)["project"]["version"])
+
+
+def locked_project_version(root: Path, package_name: str = "qq-ai-bot") -> str:
+    with (root / "uv.lock").open("rb") as handle:
+        lock = tomllib.load(handle)
+    matches = [
+        str(package["version"])
+        for package in lock["package"]
+        if package.get("name") == package_name and package.get("source", {}).get("editable") == "."
+    ]
+    if len(matches) != 1:
+        raise ReleaseValidationError(
+            f"{root / 'uv.lock'} must contain one editable {package_name} package"
+        )
+    return matches[0]
+
+
+def validate_release_identity(root: Path, tag: str) -> str:
+    tag_match = _TAG_PATTERN.fullmatch(tag)
+    if tag_match is None:
+        raise ReleaseValidationError(f"release tag must match vX.Y.Z exactly: {tag!r}")
+    tag_version = tag.removeprefix("v")
+    versions = {
+        "tag": tag_version,
+        "pyproject": project_version(root),
+        "runtime": _match_value(
+            root / "src/qq_ai_bot/__init__.py", _APP_VERSION_PATTERN, "runtime version"
+        ),
+        "uv.lock": locked_project_version(root),
+        "memory release check": _match_value(
+            root / "src/qq_ai_bot/memory/quality/release_check.py",
+            _RELEASE_VERSION_PATTERN,
+            "Memory Release Check version",
+        ),
+    }
+    if set(versions.values()) != {tag_version}:
+        rendered = ", ".join(f"{name}={value}" for name, value in versions.items())
+        raise ReleaseValidationError(f"release versions do not match: {rendered}")
+
+    worker_version = project_version(root / "services/genie_tts_worker")
+    if worker_version != "1.9.0":
+        raise ReleaseValidationError(
+            f"Genie-TTS Worker component version must remain 1.9.0, got {worker_version}"
+        )
+    worker_lock_version = locked_project_version(
+        root / "services/genie_tts_worker", "genie-tts-worker"
+    )
+    if worker_lock_version != worker_version:
+        raise ReleaseValidationError(
+            "Genie-TTS Worker pyproject.toml and uv.lock versions do not match: "
+            f"{worker_version} != {worker_lock_version}"
+        )
+    alembic_head = _match_value(
+        root / "src/qq_ai_bot/memory/quality/release_check.py",
+        _ALEMBIC_HEAD_PATTERN,
+        "Alembic head",
+    )
+    if alembic_head != "0036":
+        raise ReleaseValidationError(f"Alembic head must remain 0036, got {alembic_head}")
+    plugin_api = _match_value(
+        root / "src/yuki_plugin_sdk/api.py", _PLUGIN_API_PATTERN, "Plugin API version"
+    )
+    if plugin_api != "1.1":
+        raise ReleaseValidationError(f"Plugin API must remain 1.1, got {plugin_api}")
+    return tag_version
+
+
+def validate_tag_commit(root: Path, tag: str, main_ref: str) -> None:
+    head = _git(root, "rev-parse", "HEAD")
+    tag_commit = _git(root, "rev-parse", f"{tag}^{{commit}}")
+    if tag_commit != head:
+        raise ReleaseValidationError(f"{tag} resolves to {tag_commit}, but checkout is {head}")
+    completed = subprocess.run(
+        ["git", "merge-base", "--is-ancestor", tag_commit, main_ref],
+        cwd=root,
+        check=False,
+        capture_output=True,
+        text=True,
+    )
+    if completed.returncode != 0:
+        raise ReleaseValidationError(f"{tag} commit {tag_commit} is not reachable from {main_ref}")
+
+
+def _git(root: Path, *arguments: str) -> str:
+    completed = subprocess.run(
+        ["git", *arguments], cwd=root, check=True, capture_output=True, text=True
+    )
+    return completed.stdout.strip()
+
+
+def _write_github_output(version: str, path: str | None) -> None:
+    if not path:
+        return
+    with Path(path).open("a", encoding="utf-8", newline="\n") as handle:
+        handle.write(f"version={version}\n")
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--tag", required=True)
+    parser.add_argument("--root", type=Path, default=Path(__file__).resolve().parents[1])
+    parser.add_argument("--require-main-ancestor", action="store_true")
+    parser.add_argument("--main-ref", default="origin/main")
+    parser.add_argument("--github-output", default=os.getenv("GITHUB_OUTPUT"))
+    args = parser.parse_args()
+    root = args.root.resolve()
+    version = validate_release_identity(root, args.tag)
+    if args.require_main_ancestor:
+        validate_tag_commit(root, args.tag, args.main_ref)
+    _write_github_output(version, args.github_output)
+    print(f"validated Yuki {version}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/services/genie_tts_worker/Dockerfile
+++ b/services/genie_tts_worker/Dockerfile
@@ -14,7 +14,14 @@ COPY src ./src
 RUN uv sync --frozen --no-dev --no-editable
 
 FROM python:3.12-slim AS runtime
+ARG YUKI_VERSION=dev
+ARG VCS_REF=unknown
 ENV PATH="/worker/.venv/bin:$PATH" PYTHONUNBUFFERED=1 PYTHONDONTWRITEBYTECODE=1
+LABEL org.opencontainers.image.title="Yuki Genie TTS Worker" \
+      org.opencontainers.image.source="https://github.com/YuanYeYouTao/Yuki-QQbot" \
+      org.opencontainers.image.licenses="MIT" \
+      org.opencontainers.image.version="${YUKI_VERSION}" \
+      org.opencontainers.image.revision="${VCS_REF}"
 RUN apt-get update \
     && apt-get install --yes --no-install-recommends libportaudio2 libsndfile1 \
     && rm -rf /var/lib/apt/lists/*

--- a/src/qq_ai_bot/__init__.py
+++ b/src/qq_ai_bot/__init__.py
@@ -1,3 +1,3 @@
 """QQ AI Bot application package."""
 
-__version__ = "3.5.1"
+__version__ = "3.5.2"

--- a/src/qq_ai_bot/memory/quality/release_check.py
+++ b/src/qq_ai_bot/memory/quality/release_check.py
@@ -30,6 +30,7 @@ from qq_ai_bot.memory.quality.runner import MemoryQualityRunner
 from qq_ai_bot.persistence.database import Database
 
 _ALEMBIC_HEAD = "0036"
+_EXPECTED_RELEASE_VERSION = "3.5.2"
 
 
 class MemoryReleaseCheck:
@@ -44,7 +45,7 @@ class MemoryReleaseCheck:
         items.append(
             self._item(
                 "version",
-                __version__ == "3.5.1",
+                __version__ == _EXPECTED_RELEASE_VERSION,
                 f"project version is {__version__}",
             )
         )

--- a/tests/unit/test_configuration_contract.py
+++ b/tests/unit/test_configuration_contract.py
@@ -19,6 +19,8 @@ _EXTERNAL_ENVIRONMENT_KEYS = {
     "NAPCAT_UID",
     "NAPCAT_WEBUI_TOKEN",
     "SPEECH_WORKER_IDLE_RECYCLE_SECONDS",
+    # Compose selects immutable Yuki image tags before application settings load.
+    "YUKI_VERSION",
 }
 _COMPOSE_MANAGED_SETTINGS = {
     "APP_HOST",

--- a/tests/unit/test_versioned_docker_release.py
+++ b/tests/unit/test_versioned_docker_release.py
@@ -1,0 +1,137 @@
+from __future__ import annotations
+
+import subprocess
+import zipfile
+from pathlib import Path
+
+import pytest
+from scripts.build_release_bundle import (
+    BundleBuildError,
+    build_release_bundle,
+    select_bundle_files,
+    tracked_files,
+)
+from scripts.release_validate import (
+    ReleaseValidationError,
+    validate_release_identity,
+    validate_tag_commit,
+)
+
+ROOT = Path(__file__).resolve().parents[2]
+VERSION = "3.5.2"
+
+
+def test_release_identity_matches_all_version_surfaces() -> None:
+    assert validate_release_identity(ROOT, "v3.5.2") == VERSION
+
+
+@pytest.mark.parametrize("tag", ["3.5.2", "v3.5", "v3.5.2-rc1", "v03.5.2", "latest"])
+def test_release_identity_rejects_non_final_tags(tag: str) -> None:
+    with pytest.raises(ReleaseValidationError, match=r"vX\.Y\.Z"):
+        validate_release_identity(ROOT, tag)
+
+
+def test_release_identity_rejects_mismatched_tag() -> None:
+    with pytest.raises(ReleaseValidationError, match="do not match"):
+        validate_release_identity(ROOT, "v3.5.3")
+
+
+def test_tag_commit_must_be_reachable_from_main(tmp_path: Path) -> None:
+    _git(tmp_path, "init", "--initial-branch=main")
+    _git(tmp_path, "config", "user.email", "release-test@example.invalid")
+    _git(tmp_path, "config", "user.name", "Release Test")
+    (tmp_path / "state.txt").write_text("main\n", encoding="utf-8")
+    _git(tmp_path, "add", "state.txt")
+    _git(tmp_path, "commit", "-m", "main")
+    _git(tmp_path, "switch", "-c", "side")
+    (tmp_path / "state.txt").write_text("side\n", encoding="utf-8")
+    _git(tmp_path, "commit", "-am", "side")
+    _git(tmp_path, "tag", "v3.5.2")
+
+    with pytest.raises(ReleaseValidationError, match="not reachable"):
+        validate_tag_commit(tmp_path, "v3.5.2", "main")
+
+
+def test_bundle_allowlist_requires_persona() -> None:
+    tracked = {
+        "docker-compose.yml",
+        ".env.example",
+        "docs/releases/v3.5.2.md",
+        "config/memory_contracts.toml",
+        "config/memory_quality_gates.example.toml",
+        "config/memory_quality_gates.toml",
+        "config/model_profiles.example.toml",
+        "config/qq_face_map.json",
+        "config/system_prompt.example.md",
+    }
+    with pytest.raises(BundleBuildError, match=r"persona\.md"):
+        select_bundle_files(tracked, VERSION)
+
+
+def test_bundle_contains_only_deployment_files_and_expected_assets(tmp_path: Path) -> None:
+    tracked = tracked_files(ROOT) | {"docs/releases/v3.5.2.md"}
+    assets = build_release_bundle(ROOT, tmp_path, VERSION, tracked=tracked)
+    assert {path.name for path in assets} == {
+        "yuki-3.5.2-deploy.zip",
+        "yuki-3.5.2-deploy.tar.gz",
+        "docker-compose.yml",
+        ".env.example",
+        "Yuki-3.5.2-Upgrade.md",
+    }
+    with zipfile.ZipFile(tmp_path / "yuki-3.5.2-deploy.zip") as archive:
+        names = set(archive.namelist())
+    prefix = "yuki-3.5.2-deploy/"
+    assert f"{prefix}docker-compose.yml" in names
+    assert f"{prefix}.env.example" in names
+    assert f"{prefix}config/persona.md" in names
+    assert f"{prefix}data/speech/japanese_frontend/lexicon.toml" in names
+    assert f"{prefix}napcat-data/" in names
+    assert not any(name.startswith(f"{prefix}src/") for name in names)
+    assert not any("/tests/" in name for name in names)
+    assert not any(name.endswith(".pyc") or "__pycache__" in name for name in names)
+    assert f"{prefix}.env" not in names
+    assert f"{prefix}config/system_prompt.md" not in names
+    assert f"{prefix}config/model_profiles.toml" not in names
+
+
+def test_production_and_development_compose_are_separated() -> None:
+    production = (ROOT / "docker-compose.yml").read_text(encoding="utf-8")
+    development = (ROOT / "docker-compose.dev.yml").read_text(encoding="utf-8")
+    assert "build:" not in production
+    assert "ghcr.io/yuanyeyoutao/yuki-qqbot:${YUKI_VERSION:?missing}" in production
+    assert "ghcr.io/yuanyeyoutao/yuki-genie-tts-worker:${YUKI_VERSION:?missing}" in production
+    assert production.count("platform: linux/amd64") == 2
+    assert production.count("pull_policy: missing") == 2
+    assert "image: yuki-qqbot:dev" in development
+    assert "image: yuki-genie-tts-worker:dev" in development
+    assert development.count("pull_policy: build") == 2
+    assert development.count("build:") == 2
+
+
+def test_release_workflow_has_bootstrap_quality_smoke_and_all_assets() -> None:
+    workflow = (ROOT / ".github/workflows/release.yml").read_text(encoding="utf-8")
+    quality = (ROOT / ".github/workflows/quality.yml").read_text(encoding="utf-8")
+    assert "workflow_call:" in quality
+    assert "force_docker: true" in workflow
+    assert workflow.count(":bootstrap-amd64") == 2
+    assert "--require-main-ancestor" in workflow
+    assert "--platform linux/amd64" in workflow
+    assert '--deploy-dir "$deploy_dir" --version "$VERSION" --full' in workflow
+    assert workflow.index("Push immutable version tags") < workflow.index(
+        "Verify anonymous version pulls"
+    )
+    assert workflow.index("Verify anonymous version pulls") < workflow.index(
+        "Update latest only after public version verification"
+    )
+    for asset in (
+        "yuki-$VERSION-deploy.zip",
+        "yuki-$VERSION-deploy.tar.gz",
+        "docker-compose.yml",
+        ".env.example",
+        "Yuki-$VERSION-Upgrade.md",
+    ):
+        assert f'"dist/{asset}"' in workflow
+
+
+def _git(root: Path, *arguments: str) -> None:
+    subprocess.run(["git", *arguments], cwd=root, check=True, capture_output=True, text=True)

--- a/uv.lock
+++ b/uv.lock
@@ -758,7 +758,7 @@ wheels = [
 
 [[package]]
 name = "qq-ai-bot"
-version = "3.5.1"
+version = "3.5.2"
 source = { editable = "." }
 dependencies = [
     { name = "aiosqlite" },


### PR DESCRIPTION
## Summary
- bump Yuki to 3.5.2 while keeping Alembic 0036, Plugin API 1.1, and Genie worker component 1.9.0
- split production image-only Compose from the local development build override
- add tracked allowlist deploy archives, version/tag validation, source-free smoke and persistence checks
- make Quality reusable and add GHCR bootstrap plus immutable tag release automation
- update installation, upgrade, speech, plugin, and maintainer documentation

## Validation
- `ruff format --check src tests scripts examples migrations`
- `ruff check src tests scripts examples migrations`
- `mypy src`
- strict mypy for release scripts
- `pytest -q`: 1123 passed, 1 credential-gated Qwen test skipped
- migration matrix, example plugin contract, and 12 versioned release tests passed
- production and development Compose configuration parsed successfully
- five deploy assets generated from the staged Git allowlist

## Local limitation
Docker Desktop remained in `starting`, so image builds and container smoke are intentionally left to this PR's Ubuntu Docker job. Formal GHCR bootstrap/tag publication is not triggered by this PR.