### PR TITLE
Fix SUPERUSERS startup compatibility

### DIFF
--- a/src/qq_ai_bot/main.py
+++ b/src/qq_ai_bot/main.py
@@ -2,6 +2,11 @@
 
 from __future__ import annotations
 
+import json
+import os
+from collections.abc import Iterator
+from contextlib import contextmanager
+
 import nonebot
 from nonebot.adapters.onebot.v11 import Adapter
 from nonebot.drivers.fastapi import Driver as FastAPIDriver
@@ -12,18 +17,38 @@ from qq_ai_bot.health import HealthPayload, build_health_payload
 from qq_ai_bot.logging import configure_logging
 
 
+@contextmanager
+def _nonebot_superusers_environment(superusers: frozenset[str]) -> Iterator[None]:
+    """Expose SUPERUSERS in the JSON form expected by NoneBot during initialization."""
+
+    previous = os.environ.get("SUPERUSERS")
+    os.environ["SUPERUSERS"] = json.dumps(sorted(superusers))
+    try:
+        yield
+    finally:
+        if previous is None:
+            os.environ.pop("SUPERUSERS", None)
+        else:
+            os.environ["SUPERUSERS"] = previous
+
+
 def bootstrap(settings: Settings | None = None) -> None:
     """Configure NoneBot, routes, adapters, plugins, and resource lifecycle."""
 
     app_settings = settings or Settings()
-    nonebot.init(
-        driver="~fastapi",
-        host=app_settings.app_host,
-        port=app_settings.app_port,
-        log_level=app_settings.log_level,
-        superusers=set(app_settings.superusers),
-        onebot_access_token=app_settings.onebot_access_token or None,
-    )
+    # Yuki accepts the long-standing comma-separated SUPERUSERS setting, while
+    # NoneBot's environment source parses its own field as JSON before applying
+    # the explicit value below. Temporarily normalize the shared variable so a
+    # valid Yuki deployment cannot fail before the application starts.
+    with _nonebot_superusers_environment(app_settings.superusers):
+        nonebot.init(
+            driver="~fastapi",
+            host=app_settings.app_host,
+            port=app_settings.app_port,
+            log_level=app_settings.log_level,
+            superusers=set(app_settings.superusers),
+            onebot_access_token=app_settings.onebot_access_token or None,
+        )
     configure_logging(app_settings.log_level)
     driver = nonebot.get_driver()
     driver.register_adapter(Adapter)

--- a/tests/unit/test_main.py
+++ b/tests/unit/test_main.py
@@ -1,0 +1,28 @@
+"""Application bootstrap compatibility tests."""
+
+from __future__ import annotations
+
+import json
+import os
+
+from qq_ai_bot.main import _nonebot_superusers_environment
+
+
+def test_nonebot_superusers_environment_normalizes_and_restores_csv(
+    monkeypatch,
+) -> None:
+    monkeypatch.setenv("SUPERUSERS", "9001,9000")
+
+    with _nonebot_superusers_environment(frozenset({"9000", "9001"})):
+        assert json.loads(os.environ["SUPERUSERS"]) == ["9000", "9001"]
+
+    assert os.environ["SUPERUSERS"] == "9001,9000"
+
+
+def test_nonebot_superusers_environment_removes_temporary_value(monkeypatch) -> None:
+    monkeypatch.delenv("SUPERUSERS", raising=False)
+
+    with _nonebot_superusers_environment(frozenset()):
+        assert os.environ["SUPERUSERS"] == "[]"
+
+    assert "SUPERUSERS" not in os.environ


### PR DESCRIPTION
## What changed

- Normalize the existing comma-separated SUPERUSERS value only while NoneBot initializes.
- Restore the original environment value immediately afterward.
- Add regression coverage for populated and absent SUPERUSERS settings.

## Root cause

Yuki accepts SUPERUSERS as CSV, but NoneBot parses the same process environment variable as JSON before applying Yuki's explicit initialized value. The production deployment template therefore crashed before startup.

## Validation

- Ruff format and lint
- Mypy on src
- 54 focused tests
- Fresh source-free Docker deployment smoke with the unchanged env template