### PR TITLE
Fix speech release smoke fixture

### DIFF
--- a/scripts/release_smoke.py
+++ b/scripts/release_smoke.py
@@ -83,7 +83,9 @@ def prepare_deployment(deploy_directory: Path) -> dict[Path, str]:
         deploy_directory / "napcat-data/.release-smoke-login": "napcat-login",
         deploy_directory / "napcat-config/.release-smoke-config": "napcat-config",
         deploy_directory / "napcat-plugins/.release-smoke-plugin": "napcat-plugins",
-        deploy_directory / "data/speech/genie_data/.release-smoke": "offline-sentinel",
+        deploy_directory
+        / "data/speech/genie_data/chinese-hubert-base/.release-smoke": "offline-directory",
+        deploy_directory / "data/speech/genie_data/speaker_encoder.onnx": "offline-file-sentinel",
     }
     for path, value in sentinels.items():
         path.parent.mkdir(parents=True, exist_ok=True)

--- a/tests/unit/test_versioned_docker_release.py
+++ b/tests/unit/test_versioned_docker_release.py
@@ -11,6 +11,7 @@ from scripts.build_release_bundle import (
     select_bundle_files,
     tracked_files,
 )
+from scripts.release_smoke import prepare_deployment
 from scripts.release_validate import (
     ReleaseValidationError,
     validate_release_identity,
@@ -106,6 +107,19 @@ def test_production_and_development_compose_are_separated() -> None:
     assert "image: yuki-genie-tts-worker:dev" in development
     assert development.count("pull_policy: build") == 2
     assert development.count("build:") == 2
+
+
+def test_release_smoke_uses_non_model_genie_import_sentinels(tmp_path: Path) -> None:
+    (tmp_path / ".env.example").write_text("YUKI_VERSION=3.5.2\n", encoding="utf-8")
+
+    sentinels = prepare_deployment(tmp_path)
+
+    hubert_sentinel = tmp_path / "data/speech/genie_data/chinese-hubert-base/.release-smoke"
+    speaker_sentinel = tmp_path / "data/speech/genie_data/speaker_encoder.onnx"
+    assert sentinels[hubert_sentinel] == "offline-directory"
+    assert sentinels[speaker_sentinel] == "offline-file-sentinel"
+    assert hubert_sentinel.read_text(encoding="utf-8") == "offline-directory"
+    assert speaker_sentinel.read_text(encoding="utf-8") == "offline-file-sentinel"
 
 
 def test_release_workflow_has_bootstrap_quality_smoke_and_all_assets() -> None:


### PR DESCRIPTION
## What changed

- Place non-model smoke sentinels at the exact Genie-TTS resource paths checked during import.
- Keep real models out of the release image and deployment bundle.
- Add regression coverage for the offline speech fixture.

## Root cause

The release smoke created only a hidden file at the GenieData root. Genie-TTS requires the chinese-hubert-base path and speaker_encoder.onnx path to exist before the Worker can expose its Unix socket, even when synthesis is not exercised.

## Validation

- Ruff format and lint
- 13 versioned Docker release tests
- Local formal Worker image reaches healthy with the corrected non-model sentinels