### PR TITLE
Pass version to anonymous Compose pull

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -256,7 +256,7 @@ jobs:
           test ! -e "$anonymous_deploy_dir/pyproject.toml"
           (
             cd "$anonymous_deploy_dir"
-            docker compose --profile speech pull
+            YUKI_VERSION="$VERSION" docker compose --profile speech pull
           )
           python scripts/release_smoke.py --deploy-dir "$anonymous_deploy_dir" --version "$VERSION"
 
@@ -365,7 +365,7 @@ jobs:
           test ! -e "$deploy_dir/pyproject.toml"
           (
             cd "$deploy_dir"
-            docker compose --profile speech pull
+            YUKI_VERSION="$VERSION" docker compose --profile speech pull
           )
           python scripts/release_smoke.py --deploy-dir "$deploy_dir" --version "$VERSION"
 

--- a/tests/unit/test_versioned_docker_release.py
+++ b/tests/unit/test_versioned_docker_release.py
@@ -144,6 +144,7 @@ def test_release_workflow_has_bootstrap_quality_smoke_and_all_assets() -> None:
     assert "Verify immutable public version images" in workflow
     assert "org.opencontainers.image.revision" in workflow
     assert "yuki-source-free-anonymous" in workflow
+    assert workflow.count('YUKI_VERSION="$VERSION" docker compose --profile speech pull') == 2
     assert "--require-main-ancestor" in workflow
     assert "--platform linux/amd64" in workflow
     assert '--deploy-dir "$deploy_dir" --version "$VERSION" --full' in workflow


### PR DESCRIPTION
Fix the release finalizer's fresh deployment pull by passing the already validated YUKI_VERSION before the smoke script creates .env. Includes a workflow contract assertion.