### PR TITLE
Fix 3.5.3 Linux release smoke cleanup

### DIFF
--- a/scripts/release_smoke.py
+++ b/scripts/release_smoke.py
@@ -295,7 +295,25 @@ def verify_guided_setup(deploy_directory: Path, version: str) -> None:
         ],
         check=True,
     )
-    (deploy_directory / "data/setup/pending.json").unlink()
+    cleanup_script = (
+        "from pathlib import Path; "
+        "(Path('/deploy')/'data/setup/pending.json').unlink(missing_ok=True)"
+    )
+    subprocess.run(
+        [
+            "docker",
+            "run",
+            "--rm",
+            "--entrypoint",
+            "python",
+            "--volume",
+            f"{deploy_directory.resolve()}:/deploy",
+            image,
+            "-c",
+            cleanup_script,
+        ],
+        check=True,
+    )
 
 
 def verify_persistence(

--- a/tests/unit/test_versioned_docker_release.py
+++ b/tests/unit/test_versioned_docker_release.py
@@ -18,6 +18,7 @@ from scripts.release_smoke import (
     SmokeError,
     prepare_deployment,
     verify_bot,
+    verify_guided_setup,
     wait_healthy,
 )
 from scripts.release_validate import (
@@ -231,6 +232,29 @@ def test_release_smoke_reads_alembic_version_inside_container(
     assert len(calls) == 2
     assert all(call[:4] == ("exec", "-T", "bot", "python") for call in calls)
     assert not (tmp_path / "data/qq_ai_bot.db").exists()
+
+
+def test_release_smoke_cleans_root_owned_permission_fixture_in_container(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    calls: list[list[str]] = []
+
+    def fake_run(arguments: list[str], **kwargs: object) -> subprocess.CompletedProcess[str]:
+        calls.append(arguments)
+        return subprocess.CompletedProcess(
+            arguments,
+            0,
+            stdout="配置通过本地严格验证\n",
+        )
+
+    monkeypatch.setattr(subprocess, "run", fake_run)
+
+    verify_guided_setup(tmp_path, VERSION)
+
+    cleanup = calls[-1]
+    assert cleanup[:4] == ["docker", "run", "--rm", "--entrypoint"]
+    assert "--user" not in cleanup
+    assert "unlink(missing_ok=True)" in cleanup[-1]
 
 
 def test_release_workflow_has_bootstrap_quality_smoke_and_all_assets() -> None:


### PR DESCRIPTION
## What changed

- removes the root-owned Guided Setup permission fixture through a root container instead of the unprivileged Linux runner
- adds a regression test that verifies cleanup is executed in-container without `--user`

## Root cause

The permission probe intentionally created `data/setup/pending.json` as root, then verified that UID 10001 could read it. The GitHub runner subsequently attempted to unlink the root-owned bind-mounted file as its host user, causing the 3.5.3 source-free release smoke to fail before any image was pushed.

## Validation

- focused regression test passes
- versioned release tests: 21 passed
- Ruff format/lint and Mypy pass
- full source-free Docker smoke passes locally
- failed release run stopped before GHCR push or GitHub Release creation