### PR TITLE
fix(release): write smoke pending.json inside the container

### DIFF
--- a/scripts/release_smoke.py
+++ b/scripts/release_smoke.py
@@ -190,15 +190,35 @@ def discover_smoke_plugin_ids(deploy_directory: Path) -> tuple[str, ...]:
     return ids[:1]
 
 
-def write_plugin_pending(deploy_directory: Path) -> tuple[str, ...]:
+def write_plugin_pending(
+    deploy_directory: Path,
+    compose: Compose | None = None,
+) -> tuple[str, ...]:
     selected = discover_smoke_plugin_ids(deploy_directory)
-    pending = deploy_directory / "data/setup/pending.json"
-    pending.parent.mkdir(parents=True, exist_ok=True)
-    pending.write_text(
+    payload = (
         json.dumps({"schema_version": 1, "selected_plugins": list(selected)}, ensure_ascii=False)
-        + "\n",
-        encoding="utf-8",
+        + "\n"
     )
+    pending = deploy_directory / "data/setup/pending.json"
+    try:
+        pending.parent.mkdir(parents=True, exist_ok=True)
+        pending.write_text(payload, encoding="utf-8")
+    except OSError:
+        if compose is None:
+            raise
+        compose.run(
+            "exec",
+            "-T",
+            "bot",
+            "python",
+            "-c",
+            (
+                "from pathlib import Path; "
+                "path = Path('/app/data/setup/pending.json'); "
+                "path.parent.mkdir(parents=True, exist_ok=True); "
+                f"path.write_text({payload!r}, encoding='utf-8')"
+            ),
+        )
     return selected
 
 
@@ -259,7 +279,7 @@ def verify_bot(compose: Compose, deploy_directory: Path, version: str) -> None:
     if alembic_version != "0042":
         raise SmokeError(f"unexpected Alembic version: {alembic_version!r}")
     compose.run("exec", "-T", "bot", "qq-ai-bot-cli", "plugin", "discover", capture=True)
-    selected = write_plugin_pending(deploy_directory)
+    selected = write_plugin_pending(deploy_directory, compose)
     compose.run(
         "exec",
         "-T",

--- a/tests/unit/test_versioned_docker_release.py
+++ b/tests/unit/test_versioned_docker_release.py
@@ -250,6 +250,48 @@ def test_release_smoke_reads_alembic_version_inside_container(
     assert not (tmp_path / "data/qq_ai_bot.db").exists()
 
 
+def test_release_smoke_writes_pending_inside_container_when_host_cannot(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    calls: list[tuple[str, ...]] = []
+    original_write = Path.write_text
+
+    def blocked_write(self: Path, *args: object, **kwargs: object) -> int:
+        if self.name == "pending.json":
+            raise PermissionError("data owned by container")
+        return original_write(self, *args, **kwargs)
+
+    class FakeCompose:
+        def run(self, *arguments: str, capture: bool = False) -> str:
+            calls.append(arguments)
+            if arguments[:4] == ("exec", "-T", "bot", "python"):
+                if "pending.json" in arguments[-1]:
+                    return ""
+                if "urllib.request" in arguments[-1]:
+                    return (
+                        '{"status":"ok","version":"3.7.0","database":"ok",'
+                        '"plugin_system_enabled":true,"plugin_running_count":0}'
+                    )
+                return "0042"
+            if arguments[:5] == ("exec", "-T", "bot", "qq-ai-bot-cli", "plugin"):
+                return ""
+            if arguments[:5] == ("exec", "-T", "bot", "qq-ai-bot-cli", "setup"):
+                return ""
+            raise AssertionError(arguments)
+
+    monkeypatch.setattr(Path, "write_text", blocked_write)
+    monkeypatch.setattr("scripts.release_smoke.wait_healthy", lambda *args: "container-id")
+
+    verify_bot(FakeCompose(), tmp_path, VERSION)  # type: ignore[arg-type]
+
+    pending_writes = [
+        call
+        for call in calls
+        if call[:4] == ("exec", "-T", "bot", "python") and "pending.json" in call[-1]
+    ]
+    assert pending_writes
+
+
 def test_release_smoke_applies_builtin_plugin_pending(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:


### PR DESCRIPTION
## Summary
- Release smoke failed on `v3.7.0` because `start.sh` chowns `/app/data` to uid 10001, then the host runner could not write `data/setup/pending.json`.
- Fall back to `docker compose exec` so source-free smoke can apply plugins.

## Test plan
- [x] `tests/unit/test_versioned_docker_release.py`
- [ ] Re-run Release on `v3.7.0` after merge (tag will move to this SHA; no GHCR image was published)