### PR TITLE
Keep plugin background first-round tools[] aligned with group chat

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 ## Unreleased
 
+### Conversation / Prompt cache
+
+- 插件后台对齐会话前缀时也声明 `set_reply_target`，与群聊用户轮次同一份首轮 `tools[]`；
+  真实调用仍关闭，避免 2/3 工具来回打断 DeepSeek 前缀缓存。
+
 ### Conversation Scope / Rollup
 
 - 前台 extractive 只在未覆盖超过受保护热尾加后台 trigger 时才改写检查点，并一次压到 stop；

--- a/docs/releases/v3.7.0.md
+++ b/docs/releases/v3.7.0.md
@@ -15,7 +15,7 @@ Yuki 3.7.0 将群聊短期会话统一为 Bot + 群，并把旧分层 History Ro
 - 删除旧 history CLI 和旧 0041 运行时表；
 - Rollup 投影按 `DEFAULT_TIMEZONE` 默认的东八区显示事件时间，不再把库存 UTC 直接塞给模型；
 - 出口清理会去掉模型回显的行首 `>` 引用前缀；历史 Prompt 保持落库原文，避免 DeepSeek 前缀缓存被剥引用打断。
-- 插件后台回复声明与普通群聊相同的首轮工具 schema，但不执行工具，避免 0 工具请求把会话前缀缓存压回静态 instructions。
+- 插件后台回复声明与普通群聊相同的首轮工具 schema（含 `set_reply_target`），但不执行工具，避免 0/2/3 工具切换把会话前缀缓存压回静态 instructions。
 - 前台 Rollup 按 trigger/stop 滞回压缩：热尾未过 `raw_tail + trigger` 时只追加，避免 extractive 每轮重写第一条历史、把 DeepSeek 缓存打回静态 instructions。默认热尾 256、trigger 1024、stop 0；`LOCAL_CONTEXT_EVENT_LIMIT` 默认 2048。
 
 Alembic head 为 `0042`，Plugin API 仍为 `2.0`。

--- a/src/qq_ai_bot/services/chat.py
+++ b/src/qq_ai_bot/services/chat.py
@@ -1252,7 +1252,7 @@ class _ChatAgentBackend(AgentToolBackend):
         return call.function.name, normalized
 
     def _response_control_definitions(self) -> tuple[ChatTool, ...]:
-        if self._runtime.origin not in {
+        if self._prefix_policy_origin() not in {
             TurnOrigin.USER_MESSAGE,
             TurnOrigin.AUTONOMOUS_GROUP,
         }:

--- a/tests/unit/test_conversation_runtime_r4.py
+++ b/tests/unit/test_conversation_runtime_r4.py
@@ -576,7 +576,7 @@ async def test_plugin_background_reply_exposes_no_business_tools(database: Datab
     assert result.text == "该喝水了"
     assert seen
     names = {name for batch in seen for name in batch}
-    assert "request_tools" in names
+    assert {"request_tools", "set_reply_target"} <= names
     assert names.isdisjoint({"send_emoji", "send_voice", "memory_change"})
 
 

--- a/tests/unit/test_dynamic_tool_request.py
+++ b/tests/unit/test_dynamic_tool_request.py
@@ -350,6 +350,45 @@ async def test_reply_target_control_survives_tools_closed_and_is_bounded() -> No
 
 
 @pytest.mark.asyncio
+async def test_aligned_plugin_background_declares_same_prefix_tools_as_user() -> None:
+    control = ReplyTargetControl(visible_event_ids=frozenset({42}))
+    user_runtime = replace(_runtime(), reply_target_control=control)
+    plugin_runtime = replace(
+        user_runtime,
+        origin=TurnOrigin.PLUGIN_BACKGROUND,
+        tools_closed=True,
+        read_only=True,
+        align_conversation_prefix_tools=True,
+    )
+    agent_runtime = SimpleNamespace()
+    _, user_backend = _backend(_registry([]), user_runtime)
+    _, plugin_backend = _backend(_registry([]), plugin_runtime)
+
+    user_names = {
+        tool.name for tool in user_backend.definitions(agent_runtime, web_was_used=False)
+    }
+    plugin_names = {
+        tool.name for tool in plugin_backend.definitions(agent_runtime, web_was_used=False)
+    }
+
+    assert user_names == plugin_names
+    assert {"request_tools", "set_reply_target"} <= plugin_names
+
+    arguments = json.dumps({"event_id": 42})
+    call = ToolCall(
+        id="reply-target",
+        function=ToolFunction(name="set_reply_target", arguments=arguments),
+    )
+    plugin_backend.begin_batch((call,), agent_runtime)
+    rejected = json.loads(
+        await plugin_backend.execute("set_reply_target", arguments, agent_runtime)
+    )
+    assert rejected["ok"] is False
+    assert rejected["error"] == "tools_closed"
+    assert control.override_applied is False
+
+
+@pytest.mark.asyncio
 async def test_user_message_can_request_authorized_tools() -> None:
     calls: list[str] = []
     _service, backend = _backend(_registry(calls), _runtime())


### PR DESCRIPTION
## Summary
- 插件后台对齐会话前缀时也声明 `set_reply_target`，与群聊用户轮次同一份首轮 `tools[]`。
- 真实调用仍关闭，避免 2/3 工具来回打断 DeepSeek 前缀缓存。

## Test plan
- [x] `test_aligned_plugin_background_declares_same_prefix_tools_as_user`
- [x] `test_plugin_background_reply_exposes_no_business_tools` 现含 `set_reply_target`
- [x] 生产只重建 Bot：`7058025`，healthz 3.7.0，OneBot 已连，NapCat 容器未变
- [ ] Quality workflow 全绿