### PR TITLE
Format plugin prefix-tool alignment test for ruff

### DIFF
--- a/tests/unit/test_dynamic_tool_request.py
+++ b/tests/unit/test_dynamic_tool_request.py
@@ -364,9 +364,7 @@ async def test_aligned_plugin_background_declares_same_prefix_tools_as_user() ->
     _, user_backend = _backend(_registry([]), user_runtime)
     _, plugin_backend = _backend(_registry([]), plugin_runtime)
 
-    user_names = {
-        tool.name for tool in user_backend.definitions(agent_runtime, web_was_used=False)
-    }
+    user_names = {tool.name for tool in user_backend.definitions(agent_runtime, web_was_used=False)}
     plugin_names = {
         tool.name for tool in plugin_backend.definitions(agent_runtime, web_was_used=False)
     }


### PR DESCRIPTION
## Summary
- 补上 #41 合入后 Quality `ruff format` 未过的单测换行。

## Test plan
- [x] `ruff format --check tests/unit/test_dynamic_tool_request.py`
- [ ] Quality python job 全绿