### PR TITLE
Stop pinning origin and message tools into the first-round schema

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@
 
 - 插件后台对齐会话前缀时也声明 `set_reply_target`，与群聊用户轮次同一份首轮 `tools[]`；
   真实调用仍关闭，避免 2/3 工具来回打断 DeepSeek 前缀缓存。
+- 自主轮次不再把 `decline_reply` 钉进首轮，定时意图也不再钉 `automation_create`；
+  两者走 `request_tools`，避免和普通群聊来回改 schema。
 
 ### Conversation Scope / Rollup
 

--- a/docs/releases/v3.7.0.md
+++ b/docs/releases/v3.7.0.md
@@ -16,6 +16,7 @@ Yuki 3.7.0 将群聊短期会话统一为 Bot + 群，并把旧分层 History Ro
 - Rollup 投影按 `DEFAULT_TIMEZONE` 默认的东八区显示事件时间，不再把库存 UTC 直接塞给模型；
 - 出口清理会去掉模型回显的行首 `>` 引用前缀；历史 Prompt 保持落库原文，避免 DeepSeek 前缀缓存被剥引用打断。
 - 插件后台回复声明与普通群聊相同的首轮工具 schema（含 `set_reply_target`），但不执行工具，避免 0/2/3 工具切换把会话前缀缓存压回静态 instructions。
+- 自主轮次与定时意图不再改首轮 `tools[]`：`decline_reply` / `automation_create` 经 `request_tools` 加载。
 - 前台 Rollup 按 trigger/stop 滞回压缩：热尾未过 `raw_tail + trigger` 时只追加，避免 extractive 每轮重写第一条历史、把 DeepSeek 缓存打回静态 instructions。默认热尾 256、trigger 1024、stop 0；`LOCAL_CONTEXT_EVENT_LIMIT` 默认 2048。
 
 Alembic head 为 `0042`，Plugin API 仍为 `2.0`。

--- a/src/qq_ai_bot/services/chat.py
+++ b/src/qq_ai_bot/services/chat.py
@@ -526,11 +526,8 @@ class _ChatAgentBackend(AgentToolBackend):
         return capability_runtime
 
     def _capability_query(self) -> CapabilityQuery:
-        query_text = self._runtime.selection_query
-        if self._runtime.scheduled_automation_intent:
-            query_text = f"{query_text} 定时任务 automation_create".strip()
         return CapabilityQuery(
-            text=query_text,
+            text=self._runtime.selection_query,
             origin=RuntimeTurnOrigin(self._runtime.origin.value),
             limit=8,
             reply_excerpt=(self._runtime.inbound.reply_text or "")[:500],
@@ -633,11 +630,9 @@ class _ChatAgentBackend(AgentToolBackend):
         )
 
     def _host_priority_capability_ids(self) -> tuple[str, ...]:
-        """Pin tools implied by origin or deployment mode, not the current message."""
+        """Pin tools implied by deployment mode, not the current message or origin."""
 
         names: list[str] = []
-        if self._runtime.scheduled_automation_intent:
-            names.append("automation_create")
         web_route = self._runtime.web_route
         if self._native_web_fallback or (
             web_route is not None
@@ -648,8 +643,6 @@ class _ChatAgentBackend(AgentToolBackend):
             # from a URL, user override, or domain rule: those change tools[]
             # per message and punch the DeepSeek prefix from token 0.
             names.extend(("web_search", "read_webpage"))
-        if self._runtime.origin is TurnOrigin.AUTONOMOUS_GROUP:
-            names.append("decline_reply")
         return tuple(dict.fromkeys(names))
 
     def _scene_facts(self) -> Any:
@@ -1904,9 +1897,9 @@ class ChatService:
                     ChatMessage(
                         role="system",
                         content=(
-                            "当前消息可能涉及未来触发任务，automation_create 已作为候选能力提供。"
-                            "请根据用户的真实意图自行决定是否创建自动化；如果只是当前查询、"
-                            "列举、讨论或无需持久化，则不要创建。可以使用本轮其他已授权工具。"
+                            "当前消息可能涉及未来触发任务。如果需要创建定时任务，先用 "
+                            "request_tools 加载 automation_create，再调用它。"
+                            "如果只是当前查询、列举、讨论或无需持久化，则不要创建。"
                             "只有 automation_create 返回 confirmation=persisted 和真实 "
                             "automation_id 后，才能声称任务已经创建。"
                         ),

--- a/tests/integration/test_message_flow.py
+++ b/tests/integration/test_message_flow.py
@@ -88,11 +88,11 @@ async def test_future_mcd_query_is_persisted_instead_of_executed_immediately(
 
     def responder(request: ChatRequest) -> ChatResponse:
         nonlocal calls
+        names = {tool.name for tool in request.tools}
+        if "automation_create" not in names:
+            assert "request_tools" in names
+            return _request_tools_response("automation_create")
         calls += 1
-        assert {
-            "automation_create",
-            "request_tools",
-        } <= {tool.name for tool in request.tools}
         if calls == 1:
             return ChatResponse(
                 content="",
@@ -168,10 +168,9 @@ async def test_future_task_success_claim_is_blocked_without_create_tool_result(
     settings = make_settings(database.url, automation_enabled=True)
 
     def responder(request: ChatRequest) -> ChatResponse:
-        assert {
-            "automation_create",
-            "request_tools",
-        } <= {tool.name for tool in request.tools}
+        names = {tool.name for tool in request.tools}
+        assert "automation_create" not in names
+        assert "request_tools" in names
         return ChatResponse(content="设好了，明天九点四十五分准时查", latency_seconds=0)
 
     harness = build_harness(database, settings, FakeLLMProvider(responder))
@@ -202,7 +201,7 @@ async def test_automation_hint_keeps_web_search_available(database: Database) ->
         calls += 1
         if calls == 1:
             tool_names = {tool.name for tool in request.tools}
-            assert "automation_create" in tool_names
+            assert "automation_create" not in tool_names
             assert "web_search" in tool_names
             return ChatResponse(
                 content="",

--- a/tests/unit/test_dynamic_tool_request.py
+++ b/tests/unit/test_dynamic_tool_request.py
@@ -386,6 +386,116 @@ async def test_aligned_plugin_background_declares_same_prefix_tools_as_user() ->
     assert control.override_applied is False
 
 
+def test_host_priority_does_not_pin_origin_or_message_tools() -> None:
+    control = ReplyTargetControl(visible_event_ids=frozenset({42}))
+    scheduled = replace(_runtime(), scheduled_automation_intent=True, reply_target_control=control)
+    autonomous = replace(
+        _runtime(),
+        origin=TurnOrigin.AUTONOMOUS_GROUP,
+        read_only=True,
+        reply_target_control=control,
+    )
+    _, scheduled_backend = _backend(_registry([]), scheduled)
+    _, autonomous_backend = _backend(_registry([]), autonomous)
+
+    assert "automation_create" not in scheduled_backend._host_priority_capability_ids()
+    assert "decline_reply" not in autonomous_backend._host_priority_capability_ids()
+
+
+@pytest.mark.asyncio
+async def test_autonomous_first_round_matches_user_and_loads_decline_via_request() -> None:
+    calls: list[str] = []
+    control = ReplyTargetControl(visible_event_ids=frozenset({42}))
+    registry = _registry(calls)
+    registry.register(
+        InProcessToolProvider(
+            provider_id="core-decline",
+            source=CapabilityTrustSource.CORE,
+            definitions=lambda _runtime: (
+                ChatTool(
+                    name="decline_reply",
+                    description="决定本轮不回复",
+                    parameters={
+                        "type": "object",
+                        "properties": {
+                            "reason_code": {
+                                "type": "string",
+                                "enum": ["not_relevant"],
+                            }
+                        },
+                        "required": ["reason_code"],
+                        "additionalProperties": False,
+                    },
+                ),
+            ),
+            execute=lambda name, _arguments, _runtime: (
+                calls.append(name)
+                or {
+                    "ok": True,
+                    "data": {"called": name},
+                }
+            ),
+        )
+    )
+    user_runtime = replace(_runtime(), reply_target_control=control)
+    autonomous_runtime = replace(
+        user_runtime,
+        origin=TurnOrigin.AUTONOMOUS_GROUP,
+        read_only=True,
+    )
+    agent_runtime = SimpleNamespace()
+    _, user_backend = _backend(registry, user_runtime)
+    _, autonomous_backend = _backend(registry, autonomous_runtime)
+
+    user_names = {tool.name for tool in user_backend.definitions(agent_runtime, web_was_used=False)}
+    autonomous_names = {
+        tool.name for tool in autonomous_backend.definitions(agent_runtime, web_was_used=False)
+    }
+    assert user_names == autonomous_names
+    assert "decline_reply" not in autonomous_names
+
+    arguments = json.dumps({"query": "不用回", "max_results": 2}, ensure_ascii=False)
+    call = ToolCall(
+        id="request-decline",
+        function=ToolFunction(name=REQUEST_TOOLS_NAME, arguments=arguments),
+    )
+    autonomous_backend.begin_batch((call,), agent_runtime)
+    requested = json.loads(
+        await autonomous_backend.execute(REQUEST_TOOLS_NAME, arguments, agent_runtime)
+    )
+    assert requested["ok"] is True
+    assert any(item["name"] == "decline_reply" for item in requested["data"]["loaded_tools"])
+    assert "decline_reply" in {
+        tool.name for tool in autonomous_backend.definitions(agent_runtime, web_was_used=False)
+    }
+
+
+@pytest.mark.asyncio
+async def test_scheduled_intent_does_not_pin_automation_create() -> None:
+    calls: list[str] = []
+    control = ReplyTargetControl(visible_event_ids=frozenset({42}))
+    registry = _registry(calls)
+    registry.register(
+        InProcessToolProvider(
+            provider_id="automation",
+            source=CapabilityTrustSource.AUTOMATION,
+            definitions=lambda _runtime: (_tool("automation_create", "创建定时任务"),),
+            execute=lambda name, _arguments, _runtime: (
+                calls.append(name) or {"ok": True, "data": {"called": name}}
+            ),
+        )
+    )
+    runtime = replace(
+        _runtime(),
+        scheduled_automation_intent=True,
+        reply_target_control=control,
+    )
+    _, backend = _backend(registry, runtime)
+    names = {tool.name for tool in backend.definitions(SimpleNamespace(), web_was_used=False)}
+    assert "automation_create" not in names
+    assert "request_tools" in names
+
+
 @pytest.mark.asyncio
 async def test_user_message_can_request_authorized_tools() -> None:
     calls: list[str] = []


### PR DESCRIPTION
## Summary
- 自主轮次不再把 `decline_reply` 钉进首轮 `tools[]`。
- 定时意图不再把 `automation_create` 钉进首轮；两者都走 `request_tools`。
- 未持久化仍拦截“已经创建成功”类声称。Tavily 部署模式的 `web_search` 钉钉保持不变。

## Test plan
- [x] `test_host_priority_does_not_pin_origin_or_message_tools`
- [x] `test_autonomous_first_round_matches_user_and_loads_decline_via_request`
- [x] `test_scheduled_intent_does_not_pin_automation_create`
- [x] 定时创建 / 成功声称 / Tavily 提示相关集成测
- [x] 生产只重建 Bot：`dd1d239`，NapCat 未变
- [ ] Quality workflow 全绿