### PR TITLE
Keep Quality green for the 3.7.1 autonomous threshold

### DIFF
--- a/tests/integration/test_image_chat.py
+++ b/tests/integration/test_image_chat.py
@@ -259,6 +259,7 @@ async def test_autonomous_group_batch_never_analyzes_observed_images(database) -
     vision = FakeVisionProvider()
     settings = _vision_settings(
         "sqlite+aiosqlite:///:memory:",
+        conversation_autonomous_admission_threshold=0,
         conversation_autonomous_debounce_seconds=0.01,
         daily_chat_message_delay_min_seconds=0,
         daily_chat_message_delay_max_seconds=0,

--- a/tests/unit/test_memory_v2.py
+++ b/tests/unit/test_memory_v2.py
@@ -1127,7 +1127,14 @@ async def test_context_limits_mentioned_member_facts_to_current_group_block(
             scope_type=MemoryScopeType.PERSON_GROUP,
         )
     )
-    harness = build_harness(database, make_settings(database.url, max_context_characters=20_000))
+    harness = build_harness(
+        database,
+        make_settings(
+            database.url,
+            max_context_characters=20_000,
+            context_metadata_budget_ratio=0.25,
+        ),
+    )
     await harness.groups.set_enabled("2001", True)
     await harness.profiles.upsert(
         user_id="1002",


### PR DESCRIPTION
## Summary
- 自主门槛默认改为 80 后，观察图自主测需要显式 `threshold=0` 才能验证「观察图不跑 Vision」。
- 被 @ 成员群事实上下文测提高 metadata 预算，避免 800 字帽把 `referenced_group_fact` 挤掉。

## Test plan
- [x] `test_autonomous_group_batch_never_analyzes_observed_images`
- [x] `test_context_limits_mentioned_member_facts_to_current_group_block`
- [ ] Quality workflow 全绿


Made with [Cursor](https://cursor.com)