### PR TITLE
Load request_tools aliases from TOML for Chinese create queries

### DIFF
--- a/config/capability_search.example.toml
+++ b/config/capability_search.example.toml
@@ -1,0 +1,6 @@
+# 运营侧追加 / 覆盖 request_tools 别名。
+# 复制为 config/capability_search.toml，或设置 CAPABILITY_SEARCH_FILE。
+# 同名工具的 aliases、use_when 会与内置表合并，不会改首轮钉选。
+
+# [tool.automation_create]
+# aliases = ["设个闹钟"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -40,6 +40,9 @@ build-backend = "hatchling.build"
 [tool.hatch.build.targets.wheel]
 packages = ["src/qq_ai_bot", "src/yuki_plugin_sdk"]
 
+[tool.hatch.build.targets.wheel.force-include]
+"src/qq_ai_bot/capabilities/search_aliases.toml" = "qq_ai_bot/capabilities/search_aliases.toml"
+
 [tool.ruff]
 target-version = "py312"
 line-length = 100

--- a/src/qq_ai_bot/capabilities/provider.py
+++ b/src/qq_ai_bot/capabilities/provider.py
@@ -18,6 +18,7 @@ from qq_ai_bot.capabilities.models import (
     CapabilityRisk,
     CapabilityTrustSource,
 )
+from qq_ai_bot.capabilities.search_aliases import merge_search_terms
 from qq_ai_bot.domain.messages import ChatTool
 
 _ALL_ORIGINS = frozenset(TurnOrigin)
@@ -296,6 +297,11 @@ class ChatToolCapabilityProvider:
         )
         aliases = tool.aliases or _CORE_SEARCH_TAGS.get(tool.name, ())
         use_when = tool.use_when or _CORE_USE_WHEN.get(tool.name, ())
+        aliases, use_when = merge_search_terms(
+            aliases=tuple(aliases),
+            use_when=tuple(use_when),
+            tool_name=tool.name,
+        )
         tags = tool.tags or (namespace.split(".")[0], self._source.value)
         return CapabilityDescriptor(
             canonical_name=f"{self._source.value}.{tool.name}",

--- a/src/qq_ai_bot/capabilities/runtime.py
+++ b/src/qq_ai_bot/capabilities/runtime.py
@@ -28,6 +28,7 @@ from qq_ai_bot.capabilities.models import CapabilityDescriptor
 from qq_ai_bot.capabilities.namespace import is_valid_namespace_id, lookup_namespace
 from qq_ai_bot.capabilities.policy import CapabilityPolicyContext, CapabilityPolicyEngine
 from qq_ai_bot.capabilities.request import REQUEST_TOOLS_NAME, request_tools_definition
+from qq_ai_bot.capabilities.search_aliases import merge_search_terms
 from qq_ai_bot.capabilities.search_document import (
     SEARCH_DOCUMENT_BODY_MAX,
     CapabilitySearchDocument,
@@ -489,6 +490,11 @@ def _document_from_entry(entry: UnifiedToolCatalogEntry) -> CapabilitySearchDocu
         parameter_descriptions = tuple(item for item in descriptions if item)
     synthetic = bool((descriptor.provider_metadata or {}).get("synthetic"))
     model_name = _bounded_text(descriptor.model_name, 64) or "tool"
+    aliases, use_when = merge_search_terms(
+        aliases=descriptor.aliases,
+        use_when=descriptor.use_when,
+        tool_name=descriptor.model_name,
+    )
     return CapabilitySearchDocument(
         capability_id=_bounded_text(descriptor.model_name, 128) or model_name,
         model_name=model_name,
@@ -503,9 +509,9 @@ def _document_from_entry(entry: UnifiedToolCatalogEntry) -> CapabilitySearchDocu
             SEARCH_DOCUMENT_BODY_MAX,
         )
         or model_name,
-        aliases=descriptor.aliases,
+        aliases=aliases,
         tags=descriptor.tags,
-        use_when=descriptor.use_when,
+        use_when=use_when,
         parameter_names=parameter_names,
         parameter_descriptions=tuple(
             _bounded_text(item, 80) for item in parameter_descriptions[:12]

--- a/src/qq_ai_bot/capabilities/search_aliases.py
+++ b/src/qq_ai_bot/capabilities/search_aliases.py
@@ -1,0 +1,109 @@
+"""Load request_tools aliases from TOML instead of routing word lists."""
+
+from __future__ import annotations
+
+import os
+import tomllib
+from dataclasses import dataclass
+from functools import lru_cache
+from importlib import resources
+from pathlib import Path
+
+_DEFAULT_OVERLAY = Path("config/capability_search.toml")
+_PACKAGE_FILE = "search_aliases.toml"
+
+
+@dataclass(frozen=True, slots=True)
+class SearchTerms:
+    aliases: tuple[str, ...] = ()
+    use_when: tuple[str, ...] = ()
+
+
+@dataclass(frozen=True, slots=True)
+class SearchAliasTable:
+    tools: dict[str, SearchTerms]
+
+
+def search_terms_for(tool_name: str) -> SearchTerms:
+    return load_search_alias_table().tools.get(tool_name.strip(), SearchTerms())
+
+
+def merge_search_terms(
+    *,
+    aliases: tuple[str, ...] = (),
+    use_when: tuple[str, ...] = (),
+    tool_name: str,
+) -> tuple[tuple[str, ...], tuple[str, ...]]:
+    extra = search_terms_for(tool_name)
+    return (
+        tuple(dict.fromkeys((*aliases, *extra.aliases))),
+        tuple(dict.fromkeys((*use_when, *extra.use_when))),
+    )
+
+
+@lru_cache(maxsize=1)
+def load_search_alias_table() -> SearchAliasTable:
+    table = _parse_table(_package_payload())
+    for path in _overlay_paths():
+        if not path.is_file():
+            continue
+        table = _merge_tables(table, _parse_table(path.read_bytes()))
+    return table
+
+
+def reset_search_alias_cache() -> None:
+    load_search_alias_table.cache_clear()
+
+
+def _package_payload() -> bytes:
+    return resources.files(__package__).joinpath(_PACKAGE_FILE).read_bytes()
+
+
+def _overlay_paths() -> tuple[Path, ...]:
+    configured = os.environ.get("CAPABILITY_SEARCH_FILE", "").strip()
+    paths: list[Path] = []
+    if configured:
+        paths.append(Path(configured))
+    paths.append(_DEFAULT_OVERLAY)
+    return tuple(paths)
+
+
+def _parse_table(payload: bytes) -> SearchAliasTable:
+    raw = tomllib.loads(payload.decode("utf-8"))
+    tools_raw = raw.get("tool")
+    if tools_raw is None:
+        return SearchAliasTable(tools={})
+    if not isinstance(tools_raw, dict):
+        raise ValueError("capability search aliases [tool] must be a table")
+    tools: dict[str, SearchTerms] = {}
+    for name, spec in tools_raw.items():
+        tool_name = str(name).strip()
+        if not tool_name or not isinstance(spec, dict):
+            raise ValueError(f"invalid capability search alias entry: {name!r}")
+        tools[tool_name] = SearchTerms(
+            aliases=_string_tuple(spec.get("aliases"), field=f"tool.{tool_name}.aliases"),
+            use_when=_string_tuple(spec.get("use_when"), field=f"tool.{tool_name}.use_when"),
+        )
+    return SearchAliasTable(tools=tools)
+
+
+def _merge_tables(base: SearchAliasTable, overlay: SearchAliasTable) -> SearchAliasTable:
+    merged = dict(base.tools)
+    for name, extra in overlay.tools.items():
+        current = merged.get(name, SearchTerms())
+        merged[name] = SearchTerms(
+            aliases=tuple(dict.fromkeys((*current.aliases, *extra.aliases))),
+            use_when=tuple(dict.fromkeys((*current.use_when, *extra.use_when))),
+        )
+    return SearchAliasTable(tools=merged)
+
+
+def _string_tuple(value: object, *, field: str) -> tuple[str, ...]:
+    if value is None:
+        return ()
+    if not isinstance(value, list) or not all(isinstance(item, str) for item in value):
+        raise ValueError(f"{field} must be an array of strings")
+    items = [item.strip() for item in value if item.strip()]
+    if len(items) != len(set(items)):
+        raise ValueError(f"{field} must not contain duplicates")
+    return tuple(items)

--- a/src/qq_ai_bot/capabilities/search_aliases.toml
+++ b/src/qq_ai_bot/capabilities/search_aliases.toml
@@ -1,0 +1,26 @@
+# request_tools 检索别名。这里只声明发现用语，不写路由。
+# 运营覆盖：CAPABILITY_SEARCH_FILE 或 config/capability_search.toml
+
+[tool.automation_create]
+aliases = [
+    "提醒我",
+    "创建提醒",
+    "创建定时",
+    "创建任务",
+    "创建自动化",
+    "定时任务",
+    "定时任务能力",
+    "创建定时任务",
+]
+use_when = [
+    "把一件事安排到未来再执行",
+]
+
+[tool.automation_list]
+aliases = ["任务列表", "我的定时任务"]
+
+[tool.automation_cancel]
+aliases = ["取消任务", "取消定时"]
+
+[tool.automation_pause]
+aliases = ["暂停任务"]

--- a/src/qq_ai_bot/capabilities/search_index.py
+++ b/src/qq_ai_bot/capabilities/search_index.py
@@ -27,6 +27,7 @@ QUERY_TERM_LIMIT = 64
 FTS_CANDIDATE_LIMIT = 48
 EXACT_NAME_SCORE = 10_000.0
 EXACT_ALIAS_SCORE = 8_000.0
+ALIAS_LENGTH_BONUS = 20.0
 NAMESPACE_BONUS = 120.0
 PARAMETER_BONUS = 40.0
 AFFINITY_BONUS = 25.0
@@ -144,12 +145,14 @@ class FtsCapabilitySearchIndex:
             if exact_id is not None:
                 ranked[exact_id] = max(ranked.get(exact_id, 0.0), EXACT_NAME_SCORE)
             for alias_id in self._aliases.get(key, ()):
-                ranked[alias_id] = max(ranked.get(alias_id, 0.0), EXACT_ALIAS_SCORE)
+                ranked[alias_id] = max(ranked.get(alias_id, 0.0), _alias_score(key))
         query_terms = set(_query_terms(cleaned))
         for alias, capability_ids in self._aliases.items():
             if alias and alias in query_terms:
                 for capability_id in capability_ids:
-                    ranked[capability_id] = max(ranked.get(capability_id, 0.0), EXACT_ALIAS_SCORE)
+                    ranked[capability_id] = max(
+                        ranked.get(capability_id, 0.0), _alias_score(alias)
+                    )
         if self._connection is not None:
             match = _fts_match_expression(cleaned)
             if match:
@@ -203,6 +206,10 @@ class FtsCapabilitySearchIndex:
 
     def document(self, capability_id: str) -> CapabilitySearchDocument | None:
         return self._documents.get(capability_id)
+
+
+def _alias_score(alias: str) -> float:
+    return EXACT_ALIAS_SCORE + min(len(alias.strip()), 24) * ALIAS_LENGTH_BONUS
 
 
 def _compact(value: str) -> str:

--- a/tests/unit/test_automation_tool_recall.py
+++ b/tests/unit/test_automation_tool_recall.py
@@ -83,6 +83,11 @@ def _runtime(catalog) -> TurnCapabilityRuntime:
         "automation-create",
         "请求 automation create",
         "你去请求automation create",
+        "定时任务能力",
+        "请求定时任务",
+        "两分钟后提醒我洗澡",
+        "一分钟后提醒我喝水",
+        "创建定时任务",
     ),
 )
 def test_spaced_automation_create_outranks_read_and_cancel_tools(query: str) -> None:
@@ -120,3 +125,28 @@ async def test_request_tools_loads_automation_create_from_spaced_name() -> None:
     loaded = {item["name"] for item in payload["data"]["loaded_tools"]}
     assert "automation_create" in loaded
     assert "automation_create" in runtime.callable_capability_ids()
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    "query",
+    (
+        "定时任务能力",
+        "两分钟后提醒我洗澡",
+        "一分钟后提醒我喝水",
+    ),
+)
+async def test_request_tools_loads_automation_create_from_chinese_alias(query: str) -> None:
+    runtime = _runtime(_automation_catalog())
+    runtime.initial_exposure(
+        CapabilityQuery(text="你好", origin=TurnOrigin.USER_MESSAGE, limit=4)
+    )
+    assert "automation_create" not in runtime.callable_capability_ids()
+
+    payload = await runtime.request_tools(
+        CapabilityQuery(text=query, origin=TurnOrigin.USER_MESSAGE, limit=4)
+    )
+
+    assert payload["ok"] is True
+    loaded = {item["name"] for item in payload["data"]["loaded_tools"]}
+    assert "automation_create" in loaded

--- a/tests/unit/test_capability_search_aliases.py
+++ b/tests/unit/test_capability_search_aliases.py
@@ -1,0 +1,44 @@
+"""Capability search aliases come from TOML, not query-routing branches."""
+
+from __future__ import annotations
+
+from qq_ai_bot.capabilities.search_aliases import (
+    load_search_alias_table,
+    merge_search_terms,
+    reset_search_alias_cache,
+    search_terms_for,
+)
+
+
+def test_package_table_declares_automation_create_aliases() -> None:
+    reset_search_alias_cache()
+    terms = search_terms_for("automation_create")
+    assert "提醒我" in terms.aliases
+    assert "定时任务能力" in terms.aliases
+    assert "创建定时任务" in terms.aliases
+
+
+def test_overlay_merges_additional_aliases(tmp_path, monkeypatch) -> None:
+    overlay = tmp_path / "capability_search.toml"
+    overlay.write_text(
+        """
+[tool.automation_create]
+aliases = ["设个闹钟"]
+""",
+        encoding="utf-8",
+    )
+    monkeypatch.setenv("CAPABILITY_SEARCH_FILE", str(overlay))
+    reset_search_alias_cache()
+    try:
+        aliases, use_when = merge_search_terms(
+            aliases=("已有别名",),
+            tool_name="automation_create",
+        )
+        assert "已有别名" in aliases
+        assert "提醒我" in aliases
+        assert "设个闹钟" in aliases
+        assert use_when
+    finally:
+        monkeypatch.delenv("CAPABILITY_SEARCH_FILE", raising=False)
+        reset_search_alias_cache()
+        load_search_alias_table()


### PR DESCRIPTION
## Summary
- 群聊里模型用中文请求「定时任务能力」时，`request_tools` 现在能召回 `automation_create`。
- 别名放在 `search_aliases.toml`，可用 `config/capability_search.toml` 或 `CAPABILITY_SEARCH_FILE` 追加，不写中文路由分支。
- 更长的别名得分更高；首轮仍然不钉创建工具。

## Test plan
- [x] `tests/unit/test_automation_tool_recall.py`（含「两分钟后提醒我洗澡」「定时任务能力」）
- [x] `tests/unit/test_capability_search_aliases.py`
- [x] `tests/unit/test_capability_search_quality.py`
- [ ] Quality 全绿
- [ ] 生产群聊再试「两分钟后提醒我洗澡」
