### PR TITLE
Give autonomous turns the same prefix shape and write authority as @

### DIFF
--- a/docs/architecture/Yuki-3.7.3-prefix-shape-freeze-taskbook.md
+++ b/docs/architecture/Yuki-3.7.3-prefix-shape-freeze-taskbook.md
@@ -1,0 +1,144 @@
+# Yuki 3.7.3 自主与 @ 权威合并
+
+本文是实施合同。本轮范围收成一刀：**自主录取之后，和同一个人的 @ 轮同一套可写权威，第一跳请求形状也对齐。**
+
+不做：插件点评可写、`generate_external_reply` 收口、删除 `align_conversation_prefix_tools`、rollup 冻结前缀、发版。
+
+- **触发分开**：自主仍走 debounce / admission / 可打断；@ 仍走点名。
+- **做成之后合并**：不再 `read_only`。可写记忆、可建定时任务、可表情/语音布局；超管触发则仍可 `request_tools` 拉特权。
+- **第一跳形状对齐**：用户与自主发出去的 `tools[]` + `native_tools` 相同。插件本轮只享受「不要因为 `tools_closed` 被 runner 误钉 `read_webpage`」，执行仍关。
+
+DeepSeek 从 token 0 匹配 `tools[]` + `native_tools` + 人设 + 历史。不要扩到点餐 bundle、管理员特权钉定、rollup 水位、冻结已发送历史、或发版。不硬编码群名、插件 id 或中文路由。
+
+## 工作方式
+
+1. 先有本任务书，再改代码。
+2. 机制通用。pin / 硬顶 / `WEB_MODE` 继续走配置。
+3. 禁止动 NapCat；生产禁止现场 `docker build`。
+4. 本轮不涨版本号、不写 Release。正式版本仍是 3.7.1。
+
+## 不要做
+
+- 不钉 `admin_*`、`decline_reply`、MCP / 点餐 / 订阅。`decline_reply` 仍只给自主，走 `request_tools`，不进首轮表。
+- 不把私聊、定时任务会话、插件私聊会话并进这本群账。
+- 不改 rollup 水位，也不做「换摘要仍续写」的冻结前缀。
+- 不把规划 origin 一律改成 `USER_MESSAGE`（`decline_reply` 会从 requestable 消失）。账本 / admission / 观察仍记 `autonomous_group`。
+- 不为 github-monitor 开特例。
+- 不把「不可信」策略写进静态 instructions。
+- 不把插件点评也改成可写。
+
+## 现网事实（2026-08-21 生产群账）
+
+- 用户连聊 `request_shape_hash` 稳定为 `a51c7d36…`，命中约 90%。
+- 自主同一跳先暴露 11 个工具，立刻变成 12 个（多出 `read_webpage`），hash 变成 `3d6cd442…`。
+- 直接原因：`_run_agent` 在 `read_only` 时把 `allowed_capabilities` 收成空集 → 原生 web 绑不上 → runner 误判并 `enable_native_web_fallback()`。
+- 产品原因：自主被做成只读，和 @ 不是同一条 Agent 路。去掉 `read_only` 能消掉这条误判，但 runner 仍可能因插件 `tools_closed` 或句子改 web 表再分叉，Commit 1 还是要做。
+- 后台 extractive rollup 在自主前 1 秒换了左沿。换表后第一跳约 50% 是摘要代价；下一跳 20% 是表不一致。
+- 3.7.2 单测只比了 `definitions()` 名字，没比最终 `ChatRequest`。
+
+---
+
+## 合同 A：自主 = @ 的权威，不是只读旁路
+
+录取之后，`respond(..., autonomous=True)` 与同触发事件的 @ 轮对齐：
+
+- `read_only=False`（有图仍走现有 `contains_images` 禁写，和 @ 一样）
+- `allow_automation=True`（无视觉输入时，和 @ 一样）
+- `allow_admin_actions` / `allow_generic_onebot` 看 **触发消息发送者** 是不是超管，不看 origin
+- `scheduled_automation_intent` 不再排除 autonomous
+- 记忆：`_WRITE_ORIGINS` 纳入 `AUTONOMOUS_GROUP`；`memory_change` 做成，不再只声明
+- `set_voice_preference` 对自主开放（actor 仍是触发消息发送者）
+- 能力策略里 `DESTRUCTIVE` 对自主与 @ 相同（特权仍不进首轮，超管走 `request_tools`）
+
+仍不同的只有触发和「可以闭嘴」：
+
+- 触发：debounce / admission / 新消息打断
+- `decline_reply`：仅 `AUTONOMOUS_GROUP`，不钉首轮，`request_tools` 加载
+- 观察 / 账本 origin 仍是 `autonomous_group`，方便统计，不另开工具表
+
+Actor 就是触发那条群消息的发送者。自主改记忆、改语音偏好，等于这个人 @ 了一句同样的话。不要用 Bot 或授权用户顶替。
+
+## 合同 B：什么叫「首轮形状冻结」
+
+同一部署、同一本群账，每一轮 **第一跳** 与 origin / 当前句子 / 插件关闭态无关：
+
+- 函数 `tools[]` 的 name + description + parameters
+- `native_tools` 的类型列表
+- `request_shape_hash`
+
+允许变的：
+
+- `callable_ids`：用户与自主应对齐（同一 actor、同一 pin）；插件仍 `tools_closed`
+- 自主额外可 `request_tools` 出 `decline_reply`（只影响本轮后续跳）
+- 真实原生失败后的 Tavily 兜底（只影响本轮后续跳；下一轮第一跳回到冻结首轮）
+- TURN/dynamic 挂在当前条上的时间、记忆、外部事件策略
+
+禁止变的：
+
+- runner 在第一跳之前 `enable_native_web_fallback()` 补表
+- 因 `tools_closed` / 残存 `read_only` 清空 `allowed_capabilities` 导致原生绑不上
+- 因当前句子、URL、口头覆盖、域名规则改第一跳 web 形状
+- exclusive write 缩小已声明的首轮 schema（只许缩小 callable）
+
+`WEB_MODE` 决定部署级首轮 web 形状：
+
+- `tavily`：函数 `web_search` + `read_webpage`，无 native
+- `native` / `native_with_tavily_fallback`：Responses 下三类声明同一份 native；若已绑定 native，发出去的函数表剥掉 `web_search`/`read_webpage`，三类剥得一样
+- `disabled`：三类都无 web
+
+代价：Responses 下声明了 native_tools，模型就能发起原生检索。插件点评为了表一致也要带上；本轮接受插件可能走原生检索，仍禁止 function 写工具。
+
+---
+
+## Commit 1 — 冻结首轮形状，清 runner 改表
+
+目标：用户 / 自主 / 插件点评发出去的第一跳 `ChatRequest` 形状相同。`read_webpage` 不得在自主第一跳被钉入。
+
+### `_run_agent` 的 `allowed_capabilities`
+
+主会话三类的 **前缀绑定** 只看部署 `WEB_MODE` 是否启用 web。这个集合只给 `NativeToolBinder.bind`，不是写工具授权。
+
+### runner 禁止误判
+
+「`web_search` 已选 + native 为空 + `NATIVE_WITH_TAVILY_FALLBACK` → fallback」只允许在协议/模型能力真的绑不上 native 时触发（Chat Completions、profile 无 `NATIVE_WEB_SEARCH`）。
+
+禁止因为 `allowed_capabilities` 被收空而走这条路。
+
+`enable_native_web_fallback()` 仍可用于本轮后续跳（原生已经真正失败）。不得在第一跳、不得因 origin 改 pin。
+
+### 第一跳 web 形状只看 `WEB_MODE`
+
+`WebProviderRouter.select(content, mode)` 仍可用于事后路由、失败兜底、日志。第一跳是否绑定 native / `force_tavily_fallback` 不得跟句子、URL、口头覆盖、域名走。
+
+### `_host_priority` 与 exclusive write
+
+保持 3.7.2 pin 规则。`_native_web_fallback` 不得把 `read_webpage` 钉进 **新一轮第一跳**。exclusive write 只改 `callable_ids`，不砍已声明 schema。
+
+## Commit 2 — 自主与 @ 权威合并
+
+目标：自主不再是只读旁路。录取之后和同 actor 的 @ 轮同一套可写权威。不收插件入口，不删 `align` 旗标。
+
+- `respond`：`read_only=False`；`allow_automation` / 超管特权 / `scheduled_automation_intent` 不再排除 autonomous。
+- `_WRITE_ORIGINS` 含 `AUTONOMOUS_GROUP`。
+- `DESTRUCTIVE` 对自主与 @ 相同。
+- `set_voice_preference` 对自主开放；`decline_reply` 仍仅自主。
+- 记忆 session origin 仍记 `AUTONOMOUS_GROUP`（账本），合同按可写处理。
+
+仍分流：admission / 投递 / `decline_reply` 仅自主 / 插件 `tools_closed`。
+
+## 自审
+
+1. **只去掉 `read_only` 不够。** 记忆 `_WRITE_ORIGINS`、语音偏好、`DESTRUCTIVE`、`allow_automation` 不一起改，自主仍是半只读。
+2. **3.7.2 没测最终请求。** 验收必须经过 runner 绑定之后的 `ChatRequest`。
+3. **插件仍会 `tools_closed`。** Commit 1 的 `allowed_capabilities` 不能指望自主合并就顺带修好。
+4. **`decline_reply` 必须留在真实自主 origin。** 规划 origin 若改成 `USER_MESSAGE`，拒答会坏。不要把它钉进首轮。
+5. **Actor 是触发消息的人。** 闲聊里最后说话的人会被写成记忆主语；这和「他 @ 了同样一句话」一致。
+6. **句子改 web 表仍是洞。** 第一跳只看 `WEB_MODE`。
+7. **rollup 换左沿仍冷一跳。** 修完后换表约 50%，下一跳应回约 90%。20% 那种崩法必须消失。
+8. **换最终请求形状当天会再冷一次。**
+
+## 建议测试命令
+
+```text
+pytest tests/unit/test_agent_runner.py tests/unit/test_dynamic_tool_request.py tests/unit/test_native_web.py tests/unit/test_capability_exposure.py tests/unit/test_conversation_runtime_r4.py tests/unit/test_context_assembler.py tests/integration/test_web_search_chat.py -q
+```

--- a/src/qq_ai_bot/capabilities/exposure.py
+++ b/src/qq_ai_bot/capabilities/exposure.py
@@ -229,13 +229,6 @@ class AuthorityFirstExposurePlanner:
         ) | frozenset(tool.name for tool in kernel_tools)
         if memory_view is not None and memory_view.exclusive_namespace:
             callable_ids = _restrict_exclusive_write(selected, kernel_tools, memory_view)
-            selected = [
-                item
-                for item in selected
-                if item.descriptor.model_name in callable_ids
-                or item.descriptor.namespace_id in memory_view.eager_namespaces
-            ]
-            selected_ids = {item.descriptor.model_name for item in selected}
         omitted = sum(
             1 for item in catalog.entries if item.descriptor.model_name not in selected_ids
         )

--- a/src/qq_ai_bot/capabilities/policy.py
+++ b/src/qq_ai_bot/capabilities/policy.py
@@ -92,7 +92,8 @@ class CapabilityPolicyEngine:
             if descriptor.model_name == "set_reply_target" and not context.reply_target_available:
                 continue
             if descriptor.risk is CapabilityRisk.DESTRUCTIVE and context.origin not in {
-                TurnOrigin.USER_MESSAGE
+                TurnOrigin.USER_MESSAGE,
+                TurnOrigin.AUTONOMOUS_GROUP,
             }:
                 continue
             visible.append(descriptor)

--- a/src/qq_ai_bot/capabilities/provider.py
+++ b/src/qq_ai_bot/capabilities/provider.py
@@ -22,7 +22,7 @@ from qq_ai_bot.capabilities.search_aliases import merge_search_terms
 from qq_ai_bot.domain.messages import ChatTool
 
 _ALL_ORIGINS = frozenset(TurnOrigin)
-_DIRECT_ORIGINS = frozenset({TurnOrigin.USER_MESSAGE})
+_DIRECT_ORIGINS = frozenset({TurnOrigin.USER_MESSAGE, TurnOrigin.AUTONOMOUS_GROUP})
 _AUTONOMOUS_ORIGIN = frozenset({TurnOrigin.AUTONOMOUS_GROUP})
 _REPLY_LAYOUT_ORIGINS = frozenset({TurnOrigin.USER_MESSAGE, TurnOrigin.AUTONOMOUS_GROUP})
 _ORIGIN_OVERRIDES: dict[str, frozenset[TurnOrigin]] = {

--- a/src/qq_ai_bot/memory/runtime/resolver.py
+++ b/src/qq_ai_bot/memory/runtime/resolver.py
@@ -29,7 +29,7 @@ from qq_ai_bot.runtime.origin import TurnOrigin
 if TYPE_CHECKING:
     from qq_ai_bot.domain.conversations import ConversationScope
 
-_WRITE_ORIGINS = frozenset({TurnOrigin.USER_MESSAGE})
+_WRITE_ORIGINS = frozenset({TurnOrigin.USER_MESSAGE, TurnOrigin.AUTONOMOUS_GROUP})
 _MESSAGE_ORIGINS = frozenset({TurnOrigin.USER_MESSAGE, TurnOrigin.AUTONOMOUS_GROUP})
 
 
@@ -91,7 +91,7 @@ class MemoryAccessDecision:
 
 
 def origin_allows_persistent_write(origin: TurnOrigin) -> bool:
-    """3.6.0: only user-message turns may persist memory writes by default."""
+    """User @ turns and admitted autonomous group turns may persist writes."""
 
     return origin in _WRITE_ORIGINS
 

--- a/src/qq_ai_bot/services/agent_runner.py
+++ b/src/qq_ai_bot/services/agent_runner.py
@@ -40,7 +40,7 @@ from qq_ai_bot.llm.base import (
     LLMUnavailableError,
 )
 from qq_ai_bot.model_runtime.executor import ModelCompleter, ModelExecutor, require_model_executor
-from qq_ai_bot.model_runtime.models import ModelTask
+from qq_ai_bot.model_runtime.models import ModelCapability, ModelProtocol, ModelTask
 from qq_ai_bot.services.concurrency import ConcurrencyManager
 from qq_ai_bot.services.native_tool_binder import NativeToolBinder
 from qq_ai_bot.time.models import TimeContext
@@ -161,15 +161,12 @@ class AgentRunner:
         reusable_tool_results: dict[tuple[str, str], str] = {}
         finalization_prompt_added = False
         web_route = runtime.web_route
-        tavily_fallback = bool(
-            runtime.force_tavily_fallback
-            or (web_route is not None and web_route.provider is WebProvider.TAVILY)
-        )
         deployment_tavily = (
             web_route is not None
             and web_route.provider is WebProvider.TAVILY
             and web_route.reason is WebRouteReason.MODE
         )
+        tavily_fallback = bool(runtime.force_tavily_fallback or deployment_tavily)
         if (runtime.force_tavily_fallback or deployment_tavily) and tools is not None:
             enable_fallback = getattr(tools, "enable_native_web_fallback", None)
             if callable(enable_fallback):
@@ -200,14 +197,12 @@ class AgentRunner:
                 not tavily_fallback
                 and web_search_selected
                 and web_mode is WebMode.NATIVE_WITH_TAVILY_FALLBACK
-                and web_route is not None
-                and web_route.provider is WebProvider.NATIVE
                 and not native_definitions
+                and not self._native_web_bindable()
                 and tools is not None
             ):
-                # A Chat-Completions-only profile cannot accept native tools.
-                # Treat that as an unavailable native route before the first
-                # request, so the authorized Tavily fallback is actually shown.
+                # Only protocol/profile gaps count as native-unavailable.
+                # An empty allowed_capabilities set is not a bind failure.
                 enable_fallback = getattr(tools, "enable_native_web_fallback", None)
                 if callable(enable_fallback):
                     enable_fallback()
@@ -1025,6 +1020,12 @@ class AgentRunner:
             citations=tuple(citations),
             response_status=response_status,
             web_route=web_route,
+        )
+
+    def _native_web_bindable(self) -> bool:
+        return (
+            self._models.protocol(self._task) is ModelProtocol.RESPONSES
+            and ModelCapability.NATIVE_WEB_SEARCH in self._models.capabilities(self._task)
         )
 
     @staticmethod

--- a/src/qq_ai_bot/services/agent_tools.py
+++ b/src/qq_ai_bot/services/agent_tools.py
@@ -91,7 +91,7 @@ _URL_IN_TEXT = re.compile(r"https?://[^\s<>'\"]+", re.IGNORECASE)
 _CQ_CODE = re.compile(r"\[CQ:([a-zA-Z0-9_-]+)(?:,[^\]]*)?\]", re.IGNORECASE)
 _HISTORY_TEXT_MAX = 4000
 _HISTORY_SEGMENT_MAX = 100
-_MEMORY_CHANGE_ORIGINS = frozenset({TurnOrigin.USER_MESSAGE})
+_MEMORY_CHANGE_ORIGINS = frozenset({TurnOrigin.USER_MESSAGE, TurnOrigin.AUTONOMOUS_GROUP})
 _MEMORY_INTENT_PROPERTIES = {
     "purpose": {
         "type": "string",
@@ -767,7 +767,7 @@ class AgentToolService:
         if (
             self._voice_available_for_turn(runtime)
             and not runtime.read_only
-            and runtime.origin is TurnOrigin.USER_MESSAGE
+            and runtime.origin in {TurnOrigin.USER_MESSAGE, TurnOrigin.AUTONOMOUS_GROUP}
         ):
             tools.append(
                 ChatTool(
@@ -1032,7 +1032,10 @@ class AgentToolService:
         arguments: dict[str, Any],
         runtime: ToolRuntime,
     ) -> str:
-        if runtime.origin is not TurnOrigin.USER_MESSAGE or runtime.read_only:
+        if (
+            runtime.origin not in {TurnOrigin.USER_MESSAGE, TurnOrigin.AUTONOMOUS_GROUP}
+            or runtime.read_only
+        ):
             return self._result(error="voice_preference_forbidden", detail="本轮不能修改语音偏好")
         if self._voice_preferences is None:
             return self._result(error="speech_unavailable", detail="语音偏好服务不可用")

--- a/src/qq_ai_bot/services/chat.py
+++ b/src/qq_ai_bot/services/chat.py
@@ -1900,8 +1900,7 @@ class ChatService:
             ) = await self._run_effect(turn_snapshot, build_messages)
             exclusive_write = memory_session is not None and memory_session.exclusive_write
             scheduled_automation_intent = bool(
-                not autonomous
-                and not visual_input_present
+                not visual_input_present
                 and self._automation_tools is not None
                 and any(
                     tool.name == "automation_create"
@@ -1960,16 +1959,12 @@ class ChatService:
                 inbound=inbound,
                 gateway=gateway,
                 allow_generic_onebot=(
-                    not autonomous
-                    and not visual_input_present
-                    and inbound.sender.user_id in self._settings.superusers
+                    not visual_input_present and inbound.sender.user_id in self._settings.superusers
                 ),
                 allow_admin_actions=(
-                    not autonomous
-                    and not visual_input_present
-                    and inbound.sender.user_id in self._settings.superusers
+                    not visual_input_present and inbound.sender.user_id in self._settings.superusers
                 ),
-                allow_automation=(not autonomous and not visual_input_present),
+                allow_automation=not visual_input_present,
                 conversation_key=identity.key,
                 trigger_message_id=inbound.message_id,
                 source_display_requested=source_display_requested,
@@ -1979,7 +1974,7 @@ class ChatService:
                 mentioned_user_ids=inbound.mentioned_user_ids,
                 runtime_config=runtime_config,
                 origin=turn_origin,
-                read_only=autonomous,
+                read_only=False,
                 turn_token=turn_token,
                 turn_snapshot=turn_snapshot,
                 reply_effects=reply_effects,

--- a/src/qq_ai_bot/services/chat.py
+++ b/src/qq_ai_bot/services/chat.py
@@ -155,7 +155,7 @@ from qq_ai_bot.speech.reply_effect import (
 )
 from qq_ai_bot.time.service import TimeContextService
 from qq_ai_bot.vision.models import VisualObservation
-from qq_ai_bot.web.models import WebProvider, WebRouteReason
+from qq_ai_bot.web.models import WebMode, WebProvider, WebRouteReason
 from qq_ai_bot.web.native_sources import recover_native_web_response
 from qq_ai_bot.web.router import WebProviderRouter
 from yuki_plugin_sdk.events import EventName
@@ -1938,17 +1938,18 @@ class ChatService:
             reply_effects: list[ReplyEffect] = []
             if self._memory_context is not None and memory_session is not None:
                 self._memory_context.metrics.record_runtime_access(memory_session.contract)
-            web_route = self._web_router.select(content, runtime_config.web.mode)
-            if web_route is not None:
+            logged_web_route = self._web_router.select(content, runtime_config.web.mode)
+            web_route = self._web_router.deployment_route(runtime_config.web.mode)
+            if logged_web_route is not None:
                 logger.info(
                     "web_route_selected conversation_hash=%s provider=%s reason=%s "
                     "matched_domain=%s attempt=%d fallback_allowed=%s",
                     identifier_hash(identity.key) or "missing",
-                    web_route.provider.value,
-                    web_route.reason.value,
-                    web_route.matched_domain or "none",
-                    web_route.attempt,
-                    web_route.fallback_allowed,
+                    logged_web_route.provider.value,
+                    logged_web_route.reason.value,
+                    logged_web_route.matched_domain or "none",
+                    logged_web_route.attempt,
+                    logged_web_route.fallback_allowed,
                 )
             voice_spontaneous_allowed = await self._voice_spontaneous_allowed(
                 identity.key,
@@ -2786,6 +2787,15 @@ class ChatService:
         )
         return resolution.platform_message_id
 
+    @staticmethod
+    def _prefix_web_capabilities(config: RuntimeConfigSnapshot) -> frozenset[str]:
+        """Prefix native-web binding follows WEB_MODE, not origin or tools_closed."""
+
+        mode = config.web.mode
+        if mode is WebMode.DISABLED:
+            return frozenset()
+        return frozenset({"web", "web_search"})
+
     async def _run_agent(
         self,
         conversation_key: str,
@@ -2827,11 +2837,7 @@ class ChatService:
                 gateway=runtime.gateway,
                 runtime_config=config,
                 current_time=current_time,
-                allowed_capabilities=(
-                    frozenset({"web", "web_search"})
-                    if not runtime.tools_closed and not runtime.read_only
-                    else frozenset()
-                ),
+                allowed_capabilities=self._prefix_web_capabilities(config),
                 max_tool_calls=config.agent.max_tool_calls,
                 max_model_requests=(
                     min(
@@ -2975,7 +2981,7 @@ class ChatService:
             turn_snapshot=turn_snapshot,
             reply_target_control=ReplyTargetControl(visible_event_ids=context.visible_event_ids),
             selection_query=event.content,
-            web_route=self._web_router.select("", runtime.web.mode),
+            web_route=self._web_router.deployment_route(runtime.web.mode),
             max_model_requests_override=min(2, runtime.agent.max_model_requests),
             prompt_diagnostics=PromptRequestDiagnostics(
                 conversation_prefix_hash=composition.metrics.conversation_prefix_hash,

--- a/src/qq_ai_bot/speech/preference_service.py
+++ b/src/qq_ai_bot/speech/preference_service.py
@@ -36,7 +36,7 @@ class VoicePreferenceService:
         if (
             change is None
             or change.duration is not VoicePreferenceDuration.PERSISTENT
-            or origin is not TurnOrigin.USER_MESSAGE
+            or origin not in {TurnOrigin.USER_MESSAGE, TurnOrigin.AUTONOMOUS_GROUP}
         ):
             return None
         return await self._repository.set(
@@ -53,9 +53,9 @@ class VoicePreferenceService:
         source_message_id: str,
         origin: TurnOrigin,
     ) -> PersonSpeechPreference | None:
-        """Write a long-lived preference only from a real user-message tool call."""
+        """Write a long-lived preference from a user @ or admitted autonomous turn."""
 
-        if origin is not TurnOrigin.USER_MESSAGE:
+        if origin not in {TurnOrigin.USER_MESSAGE, TurnOrigin.AUTONOMOUS_GROUP}:
             return None
         return await self._repository.set(
             user_id,

--- a/src/qq_ai_bot/web/router.py
+++ b/src/qq_ai_bot/web/router.py
@@ -40,6 +40,11 @@ class WebProviderRouter:
         self._fallback_on_access_denied = fallback_on_access_denied
         self._fallback_on_target_miss = fallback_on_target_miss
 
+    def deployment_route(self, mode: WebMode | str) -> WebRouteDecision | None:
+        """First-hop web shape from WEB_MODE only, ignoring the current sentence."""
+
+        return self.select("", mode)
+
     def select(self, message: str, mode: WebMode | str) -> WebRouteDecision | None:
         """Choose the initial provider from deployment mode and current user input."""
 

--- a/tests/unit/test_capability_runtime_security.py
+++ b/tests/unit/test_capability_runtime_security.py
@@ -289,6 +289,39 @@ def test_read_only_origin_hides_destructive_and_writes() -> None:
     assert [item.model_name for item in visible] == ["web_search"]
 
 
+def test_destructive_is_visible_for_user_and_autonomous_not_plugin() -> None:
+    destructive = _descriptor(
+        "admin_execute_action",
+        namespace="admin.action.write",
+        effect=CapabilityEffect.WRITE_STATE,
+        risk=CapabilityRisk.DESTRUCTIVE,
+        permissions=frozenset({"superuser"}),
+    )
+    engine = CapabilityPolicyEngine()
+    context = {
+        "authority": AuthorityContext(
+            actor_user_id="u1",
+            is_superuser=True,
+            permissions=frozenset({"superuser"}),
+        )
+    }
+    user = engine.visible(
+        (destructive,),
+        CapabilityPolicyContext(**context, origin=TurnOrigin.USER_MESSAGE),
+    )
+    autonomous = engine.visible(
+        (destructive,),
+        CapabilityPolicyContext(**context, origin=TurnOrigin.AUTONOMOUS_GROUP),
+    )
+    plugin = engine.visible(
+        (destructive,),
+        CapabilityPolicyContext(**context, origin=TurnOrigin.PLUGIN_BACKGROUND),
+    )
+    assert [item.model_name for item in user] == ["admin_execute_action"]
+    assert [item.model_name for item in autonomous] == ["admin_execute_action"]
+    assert plugin == ()
+
+
 def test_catalog_entry_round_trip_for_security_fixtures() -> None:
     catalog = UnifiedToolCatalog(
         entries=(_entry(_descriptor("web_search", namespace="web.search")),),

--- a/tests/unit/test_commands_and_chat.py
+++ b/tests/unit/test_commands_and_chat.py
@@ -511,7 +511,7 @@ async def test_mutation_turn_uses_auto_with_only_write_tool_and_receipt_contract
     assert request.tool_choice == "auto"
     tool_names = {tool.name for tool in request.tools}
     assert "memory_change" in tool_names
-    assert tool_names <= {"memory_change", "request_tools"}
+    assert "request_tools" in tool_names
     assert any("真实工具回执" in (message.content or "") for message in request.messages)
     assert sender.messages[0].text == "记忆变更未执行，本轮没有取得任何有效的记忆写入回执。"
 

--- a/tests/unit/test_dynamic_tool_request.py
+++ b/tests/unit/test_dynamic_tool_request.py
@@ -392,7 +392,7 @@ def test_host_priority_does_not_pin_origin_or_message_tools() -> None:
     autonomous = replace(
         _runtime(),
         origin=TurnOrigin.AUTONOMOUS_GROUP,
-        read_only=True,
+        read_only=False,
         reply_target_control=control,
     )
     _, scheduled_backend = _backend(_registry([]), scheduled)
@@ -421,7 +421,7 @@ def test_host_priority_uses_config_pins_not_origin() -> None:
             web=SimpleNamespace(max_calls_per_turn=3),
         ),
     )
-    autonomous = replace(runtime, origin=TurnOrigin.AUTONOMOUS_GROUP, read_only=True)
+    autonomous = replace(runtime, origin=TurnOrigin.AUTONOMOUS_GROUP, read_only=False)
     plugin = replace(
         runtime,
         origin=TurnOrigin.PLUGIN_BACKGROUND,
@@ -495,7 +495,7 @@ def test_user_autonomous_and_plugin_declare_the_same_pinned_tools() -> None:
             web=SimpleNamespace(max_calls_per_turn=3),
         ),
     )
-    autonomous = replace(runtime, origin=TurnOrigin.AUTONOMOUS_GROUP, read_only=True)
+    autonomous = replace(runtime, origin=TurnOrigin.AUTONOMOUS_GROUP, read_only=False)
     plugin = replace(
         runtime,
         origin=TurnOrigin.PLUGIN_BACKGROUND,
@@ -519,6 +519,104 @@ def test_user_autonomous_and_plugin_declare_the_same_pinned_tools() -> None:
     assert set(pins) <= user_names
     assert "decline_reply" not in user_names
     assert "admin_execute_action" not in user_names
+    user_callable = set(user_backend._callable_tool_names)
+    autonomous_callable = set(autonomous_backend._callable_tool_names)
+    assert user_callable == autonomous_callable
+    assert set(pins) <= user_callable
+    assert "decline_reply" not in autonomous_callable
+
+
+@pytest.mark.asyncio
+async def test_autonomous_can_execute_declared_writes_plugin_stays_closed() -> None:
+    calls: list[str] = []
+    pins = ("memory_change", "send_emoji")
+    registry = _registry(calls)
+
+    async def execute_write(name: str, _arguments: str, _runtime: object) -> object:
+        calls.append(name)
+        return {"ok": True, "data": {"called": name}}
+
+    registry.register(
+        InProcessToolProvider(
+            provider_id="core-writes",
+            source=CapabilityTrustSource.CORE,
+            definitions=lambda _runtime: (
+                _tool("memory_change", "改记忆"),
+                _tool("send_emoji", "发表情"),
+            ),
+            execute=execute_write,
+        )
+    )
+    runtime = replace(
+        _runtime(),
+        runtime_config=SimpleNamespace(
+            tooling=SimpleNamespace(
+                first_round_pin_ids=pins,
+                first_round_hard_cap=16,
+                schema_token_budget=12_000,
+                result_token_budget=8_000,
+                result_item_limit=32,
+                result_artifact_enabled=False,
+                result_artifact_retention_seconds=86400,
+            ),
+            mcp=None,
+            agent=SimpleNamespace(tool_result_max_characters=32_000),
+            web=SimpleNamespace(max_calls_per_turn=3),
+        ),
+        reply_effects=[],
+    )
+    autonomous = replace(runtime, origin=TurnOrigin.AUTONOMOUS_GROUP, read_only=False)
+    plugin = replace(
+        runtime,
+        origin=TurnOrigin.PLUGIN_BACKGROUND,
+        tools_closed=True,
+        read_only=True,
+        align_conversation_prefix_tools=True,
+        reply_effects=None,
+    )
+    agent_runtime = SimpleNamespace()
+    _, user_backend = _backend(registry, runtime)
+    _, autonomous_backend = _backend(registry, autonomous)
+    _, plugin_backend = _backend(registry, plugin)
+    user_backend.definitions(agent_runtime, web_was_used=False)
+    autonomous_backend.definitions(agent_runtime, web_was_used=False)
+    plugin_backend.definitions(agent_runtime, web_was_used=False)
+
+    arguments = "{}"
+    call = ToolCall(
+        id="memory-write",
+        function=ToolFunction(name="memory_change", arguments=arguments),
+    )
+    autonomous_backend.begin_batch((call,), agent_runtime)
+    written = json.loads(
+        await autonomous_backend.execute("memory_change", arguments, agent_runtime)
+    )
+    assert written["ok"] is True, json.dumps(written, ensure_ascii=False)
+    assert "memory_change" in calls
+
+    user_backend.begin_batch(
+        (
+            ToolCall(
+                id="user-write", function=ToolFunction(name="memory_change", arguments=arguments)
+            ),
+        ),
+        agent_runtime,
+    )
+    user_written = json.loads(await user_backend.execute("memory_change", arguments, agent_runtime))
+    assert user_written["ok"] is True
+
+    plugin_backend.begin_batch(
+        (
+            ToolCall(
+                id="plugin-write",
+                function=ToolFunction(name="memory_change", arguments=arguments),
+            ),
+        ),
+        agent_runtime,
+    )
+    rejected = json.loads(await plugin_backend.execute("memory_change", arguments, agent_runtime))
+    assert rejected["ok"] is False
+    assert rejected["error"] == "tools_closed"
 
 
 @pytest.mark.asyncio
@@ -560,7 +658,7 @@ async def test_autonomous_first_round_matches_user_and_loads_decline_via_request
     autonomous_runtime = replace(
         user_runtime,
         origin=TurnOrigin.AUTONOMOUS_GROUP,
-        read_only=True,
+        read_only=False,
     )
     agent_runtime = SimpleNamespace()
     _, user_backend = _backend(registry, user_runtime)
@@ -781,22 +879,26 @@ def test_mutation_access_exposes_only_memory_write_capability_initially() -> Non
     _service, backend = _backend(registry, exclusive)
 
     names = {tool.name for tool in backend.definitions(SimpleNamespace(), web_was_used=False)}
+    callable_ids = set(backend._callable_tool_names)
 
     assert "memory_change" in names
+    assert "memory_change" in callable_ids
     assert "get_my_capabilities" not in names
     assert "get_person_memories" not in names
-    assert "admin_execute_action" not in names
-    assert "web_search" not in names
+    assert "admin_execute_action" not in callable_ids
+    assert "web_search" not in callable_ids
 
     locator = replace(exclusive, memory_session=_exclusive_session(locator_open=True))
     _ignored, locator_backend = _backend(registry, locator)
     locator_names = {
         tool.name for tool in locator_backend.definitions(SimpleNamespace(), web_was_used=False)
     }
+    locator_callable = set(locator_backend._callable_tool_names)
     assert "memory_change" in locator_names
     assert "get_person_memories" in locator_names
-    assert "admin_execute_action" not in locator_names
-    assert "web_search" not in locator_names
+    assert "get_person_memories" in locator_callable
+    assert "admin_execute_action" not in locator_callable
+    assert "web_search" not in locator_callable
 
     read_backend = _ChatAgentBackend(  # type: ignore[arg-type]
         _Service(registry),

--- a/tests/unit/test_memory_mutation.py
+++ b/tests/unit/test_memory_mutation.py
@@ -1456,11 +1456,11 @@ async def test_user_message_turn_can_create_self_memory_from_current_event(
 
 
 @pytest.mark.asyncio
-async def test_autonomous_group_turn_cannot_change_memory(database: Database) -> None:
+async def test_autonomous_group_turn_can_change_memory_like_user(database: Database) -> None:
     mutations, facts, ledger, _processor = _service(database, self_memory_enabled=True)
     event = await _event(
         ledger,
-        message_id="autonomous-group-no-write",
+        message_id="autonomous-group-can-write",
         sender_user_id="1001",
         group_id="3001",
         content="请把刚才的讨论记下来",
@@ -1495,8 +1495,8 @@ async def test_autonomous_group_turn_cannot_change_memory(database: Database) ->
         current_group_id=event.group_id,
         origin=TurnOrigin.AUTONOMOUS_GROUP,
     )
-    assert "memory_change" not in {tool.name for tool in tools.definitions(runtime)}
-    rejected = json.loads(
+    assert "memory_change" in {tool.name for tool in tools.definitions(runtime)}
+    response = json.loads(
         await tools.execute(
             "memory_change",
             json.dumps(
@@ -1504,19 +1504,21 @@ async def test_autonomous_group_turn_cannot_change_memory(database: Database) ->
                     "operation": "create",
                     "target": {"subject_ref": "self", "scope_type": "self"},
                     "visibility": "current_scope",
-                    "new_content": "自主群聊不应写入记忆",
-                    "memory_key": "episode:should_not_write",
+                    "new_content": "自主群聊与 @ 同一套可写权威",
+                    "memory_key": "episode:autonomous-can-write",
                     "category": "self_episode",
                     "kind": "episode",
-                    "reason": "autonomous write must stay denied",
+                    "reason": "admitted autonomous turn may persist memory",
                 },
                 ensure_ascii=False,
             ),
             runtime,
         )
     )
-    assert not rejected["ok"]
-    assert rejected["error"] == "memory_change_unavailable"
+    assert response["ok"]
+    fact = await facts.get_fact(response["data"]["new_fact_id"])
+    assert fact is not None
+    assert fact.scope_type is MemoryScopeType.SELF
 
 
 @pytest.mark.asyncio

--- a/tests/unit/test_memory_runtime_resolver.py
+++ b/tests/unit/test_memory_runtime_resolver.py
@@ -139,10 +139,10 @@ class TestOriginAndAuthority:
         assert decision.contract.write_policy is MemoryWritePolicy.DISABLED
         assert decision.reason is MemoryAccessReason.ORIGIN_RESTRICTED
 
-    def test_autonomous_group_cannot_persist_write(self) -> None:
+    def test_autonomous_group_can_persist_write_like_user(self) -> None:
         decision = resolve_memory_access(
             authority=_authority(TurnOrigin.AUTONOMOUS_GROUP),
             scene=_scene(),
         )
-        assert decision.contract.write_transition is MemoryWriteTransition.DENIED
-        assert decision.reason is MemoryAccessReason.ORIGIN_WRITE_DENIED
+        assert decision.reason is MemoryAccessReason.ORDINARY_NATURAL_LANGUAGE
+        assert decision.contract.write_transition is MemoryWriteTransition.REQUESTABLE

--- a/tests/unit/test_native_web.py
+++ b/tests/unit/test_native_web.py
@@ -2,6 +2,8 @@
 
 from __future__ import annotations
 
+from types import SimpleNamespace
+
 import pytest
 from pydantic import ValidationError
 
@@ -14,6 +16,7 @@ from qq_ai_bot.domain.messages import (
     ResponseCitation,
 )
 from qq_ai_bot.model_runtime.models import ModelCapability, ModelProtocol
+from qq_ai_bot.services.chat import ChatService
 from qq_ai_bot.services.native_tool_binder import NativeToolBinder
 from qq_ai_bot.web.models import WebMode
 from qq_ai_bot.web.native_sources import recover_native_web_response
@@ -32,6 +35,18 @@ def test_web_mode_preserves_legacy_behavior_and_native_needs_no_tavily_key() -> 
     )
     assert native.web.mode is WebMode.NATIVE
     assert native.web_configured
+
+
+def test_prefix_web_capabilities_follow_web_mode_only() -> None:
+    disabled = SimpleNamespace(web=SimpleNamespace(mode=WebMode.DISABLED))
+    native = SimpleNamespace(web=SimpleNamespace(mode=WebMode.NATIVE))
+    hybrid = SimpleNamespace(web=SimpleNamespace(mode=WebMode.NATIVE_WITH_TAVILY_FALLBACK))
+    tavily = SimpleNamespace(web=SimpleNamespace(mode=WebMode.TAVILY))
+
+    assert ChatService._prefix_web_capabilities(disabled) == frozenset()  # type: ignore[arg-type]
+    assert ChatService._prefix_web_capabilities(native) == frozenset({"web", "web_search"})  # type: ignore[arg-type]
+    assert ChatService._prefix_web_capabilities(hybrid) == frozenset({"web", "web_search"})  # type: ignore[arg-type]
+    assert ChatService._prefix_web_capabilities(tavily) == frozenset({"web", "web_search"})  # type: ignore[arg-type]
 
 
 def test_native_binder_intersects_scope_mode_protocol_and_capability() -> None:

--- a/tests/unit/test_responses_runtime.py
+++ b/tests/unit/test_responses_runtime.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import json
+from dataclasses import replace
 from datetime import UTC, datetime
 from pathlib import Path
 from types import SimpleNamespace
@@ -515,3 +516,75 @@ async def test_native_timeout_falls_back_once_without_exposing_both_web_tools() 
     assert executor.requests[0].native_tools and not executor.requests[0].tools
     assert executor.requests[1].tools and not executor.requests[1].native_tools
     assert backend.enabled
+
+
+class _PinningFallbackBackend(_FallbackBackend):
+    def definitions(self, runtime: AgentRuntime, *, web_was_used: bool) -> tuple[ChatTool, ...]:
+        del runtime, web_was_used
+        tools = [ChatTool(name="web_search", description="search", parameters={})]
+        if self.enabled:
+            tools.append(ChatTool(name="read_webpage", description="read", parameters={}))
+        return tuple(tools)
+
+
+@pytest.mark.asyncio
+async def test_empty_allowed_capabilities_do_not_trigger_first_hop_tavily() -> None:
+    executor = _ResponsesExecutor(
+        [ChatResponse(content="ok", latency_seconds=0)],
+    )
+    backend = _PinningFallbackBackend()
+    await AgentRunner(
+        cast(TaskModelExecutor, executor),
+        ConcurrencyManager(1),
+    ).run(
+        (ChatMessage(role="user", content="search"),),
+        _runtime(
+            max_requests=2,
+            web_mode="native_with_tavily_fallback",
+            allowed=frozenset(),
+        ),
+        backend,
+    )
+
+    first = executor.requests[0]
+    assert {tool.name for tool in first.tools} == {"web_search"}
+    assert not first.native_tools
+    assert backend.enabled is False
+
+
+@pytest.mark.asyncio
+async def test_first_hop_tools_and_native_match_across_message_origins() -> None:
+    shapes: list[tuple[frozenset[str], tuple[str, ...]]] = []
+    for origin in (
+        TurnOrigin.USER_MESSAGE,
+        TurnOrigin.AUTONOMOUS_GROUP,
+        TurnOrigin.PLUGIN_BACKGROUND,
+    ):
+        executor = _ResponsesExecutor(
+            [ChatResponse(content="ok", latency_seconds=0)],
+        )
+        runtime = _runtime(
+            max_requests=2,
+            web_mode="native_with_tavily_fallback",
+            allowed=frozenset({"web", "web_search"}),
+        )
+        runtime = replace(runtime, origin=origin)
+        await AgentRunner(
+            cast(TaskModelExecutor, executor),
+            ConcurrencyManager(1),
+        ).run(
+            (ChatMessage(role="user", content="search"),),
+            runtime,
+            _FallbackBackend(),
+        )
+        first = executor.requests[0]
+        shapes.append(
+            (
+                frozenset(tool.name for tool in first.tools),
+                tuple(tool.type.value for tool in first.native_tools),
+            )
+        )
+
+    assert shapes[0] == shapes[1] == shapes[2]
+    assert shapes[0][0] == frozenset()
+    assert shapes[0][1] == ("web_search",)

--- a/tests/unit/test_voice_governance.py
+++ b/tests/unit/test_voice_governance.py
@@ -86,6 +86,32 @@ async def test_persistent_voice_preference_is_person_scoped_and_cascades(
     assert await repository.get("1001") is None
 
 
+@pytest.mark.asyncio
+async def test_autonomous_turn_can_write_voice_preference(database: Database) -> None:
+    people = PeopleRepository(database)
+    repository = VoicePreferenceRepository(database)
+    service = VoicePreferenceService(repository)
+    await people.observe(user_id="1001", nickname="测试用户")
+
+    saved = await service.set_persistent(
+        user_id="1001",
+        mode=VoicePreferenceMode.PREFER_VOICE,
+        source_message_id="auto-pref",
+        origin=TurnOrigin.AUTONOMOUS_GROUP,
+    )
+    assert saved is not None
+    assert saved.mode is VoicePreferenceMode.PREFER_VOICE
+
+    denied = await service.set_persistent(
+        user_id="1001",
+        mode=VoicePreferenceMode.TEXT_ONLY,
+        source_message_id="plugin-pref",
+        origin=TurnOrigin.PLUGIN_BACKGROUND,
+    )
+    assert denied is None
+    assert (await repository.get("1001")).mode is VoicePreferenceMode.PREFER_VOICE
+
+
 def test_voice_ledger_separates_spoken_text_from_internal_metadata() -> None:
     technical_summary = "Yuki 发送了一条语音，声线：roxy，风格：happy，语言：jp"
     media_only = OutboundMessage(

--- a/tests/unit/test_web_router.py
+++ b/tests/unit/test_web_router.py
@@ -174,3 +174,21 @@ def test_router_ignores_private_urls_and_can_disable_outcome_fallbacks() -> None
         ),
     )
     assert router.native_terminal_failure(decision, events=failed, citations=()) is None
+
+
+def test_deployment_route_ignores_sentence_url_and_override() -> None:
+    router = WebProviderRouter(tavily_domains=frozenset({"github.com"}))
+    sentence = router.select(
+        "Tavily搜索 https://github.com/example/project",
+        WebMode.NATIVE_WITH_TAVILY_FALLBACK,
+    )
+    prefix = router.deployment_route(WebMode.NATIVE_WITH_TAVILY_FALLBACK)
+    tavily_mode = router.deployment_route(WebMode.TAVILY)
+
+    assert sentence is not None
+    assert sentence.provider is WebProvider.TAVILY
+    assert prefix is not None
+    assert prefix.provider is WebProvider.NATIVE
+    assert tavily_mode is not None
+    assert tavily_mode.provider is WebProvider.TAVILY
+    assert tavily_mode.reason is WebRouteReason.MODE


### PR DESCRIPTION
## Summary
- Freeze first-round `tools[]` + `native_tools` on `WEB_MODE` so autonomous / plugin / `@` no longer fork the DeepSeek prefix (the production `read_webpage` pin).
- After admission, autonomous turns use the same writable authority as the triggering user''s `@` turn: memory, automation, voice preference, and superuser `request_tools`.
- Plugin commentary still declares the same first-round schema but stays `tools_closed`. Version stays 3.7.1.

## Test plan
- [x] `uv run pytest` on agent runner, dynamic tools, native web, exposure, conversation runtime, context assembler, web search chat, responses runtime
- [x] Autonomous `memory_change` / voice preference succeed; plugin write stays closed; `@` still cannot `decline_reply`
- [ ] Production: first-hop `request_shape_hash` matches user and autonomous after deploy
- [ ] Next user turn after an autonomous turn should return to ~90% cache hit (rollup-cold first hop still ~50%)
- [ ] NapCat container id unchanged; `/healthz` version 3.7.1 and OneBot connected
